### PR TITLE
Feature/apvs 664/extend expense routing to route between expense pages

### DIFF
--- a/app/routes/first-time/eligibility/claim/accommodation-details.js
+++ b/app/routes/first-time/eligibility/claim/accommodation-details.js
@@ -6,7 +6,8 @@ module.exports = function (router) {
     UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/accommodation-details', {
       reference: req.params.reference,
-      claim: req.params.claim
+      claim: req.params.claim,
+      params: expenseUrlRouter.parseParams(req.query)
     })
   })
 

--- a/app/routes/first-time/eligibility/claim/accommodation-details.js
+++ b/app/routes/first-time/eligibility/claim/accommodation-details.js
@@ -3,6 +3,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/accommodation', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/accommodation-details', {
       reference: req.params.reference,
       claim: req.params.claim

--- a/app/routes/first-time/eligibility/claim/bus-details.js
+++ b/app/routes/first-time/eligibility/claim/bus-details.js
@@ -6,7 +6,8 @@ module.exports = function (router) {
     UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/bus-details', {
       reference: req.params.reference,
-      claim: req.params.claim
+      claim: req.params.claim,
+      params: expenseUrlRouter.parseParams(req.query)
     })
   })
 

--- a/app/routes/first-time/eligibility/claim/bus-details.js
+++ b/app/routes/first-time/eligibility/claim/bus-details.js
@@ -3,6 +3,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/bus', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/bus-details', {
       reference: req.params.reference,
       claim: req.params.claim

--- a/app/routes/first-time/eligibility/claim/car-details.js
+++ b/app/routes/first-time/eligibility/claim/car-details.js
@@ -5,10 +5,6 @@ module.exports = function (router) {
   // TODO: Replace the subbed 'to' and 'from' values with real values associated with this claim.
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/car', function (req, res) {
     UrlPathValidator(req.params)
-
-    console.log('GET - Query Params (car page):')
-    console.log(req.query)
-
     return res.render('first-time/eligibility/claim/car-details', {
       reference: req.params.reference,
       claim: req.params.claim,
@@ -21,10 +17,6 @@ module.exports = function (router) {
   // TODO: Add form validation.
   router.post('/first-time-claim/eligibility/:reference/claim/:claim/car', function (req, res) {
     UrlPathValidator(req.params)
-
-    console.log('POST - Query Params (car page):')
-    console.log(req.query)
-
     return res.redirect(expenseUrlRouter.getRedirectUrl(req))
   })
 }

--- a/app/routes/first-time/eligibility/claim/car-details.js
+++ b/app/routes/first-time/eligibility/claim/car-details.js
@@ -5,6 +5,10 @@ module.exports = function (router) {
   // TODO: Replace the subbed 'to' and 'from' values with real values associated with this claim.
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/car', function (req, res) {
     UrlPathValidator(req.params)
+
+    console.log('GET - Query Params (car pages):')
+    console.log(req.query)
+
     return res.render('first-time/eligibility/claim/car-details', {
       reference: req.params.reference,
       claim: req.params.claim,
@@ -16,6 +20,10 @@ module.exports = function (router) {
   // TODO: Add form validation.
   router.post('/first-time-claim/eligibility/:reference/claim/:claim/car', function (req, res) {
     UrlPathValidator(req.params)
+
+    console.log('POST - Query Params (car pages):')
+    console.log(req.query)
+
     return res.redirect(expenseUrlRouter.getRedirectUrl(req))
   })
 }

--- a/app/routes/first-time/eligibility/claim/car-details.js
+++ b/app/routes/first-time/eligibility/claim/car-details.js
@@ -4,6 +4,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 module.exports = function (router) {
   // TODO: Replace the subbed 'to' and 'from' values with real values associated with this claim.
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/car', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/car-details', {
       reference: req.params.reference,
       claim: req.params.claim,

--- a/app/routes/first-time/eligibility/claim/car-details.js
+++ b/app/routes/first-time/eligibility/claim/car-details.js
@@ -6,12 +6,13 @@ module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/car', function (req, res) {
     UrlPathValidator(req.params)
 
-    console.log('GET - Query Params (car pages):')
+    console.log('GET - Query Params (car page):')
     console.log(req.query)
 
     return res.render('first-time/eligibility/claim/car-details', {
       reference: req.params.reference,
       claim: req.params.claim,
+      params: expenseUrlRouter.parseParams(req.query),
       from: 'London',
       to: 'Hewell'
     })
@@ -21,7 +22,7 @@ module.exports = function (router) {
   router.post('/first-time-claim/eligibility/:reference/claim/:claim/car', function (req, res) {
     UrlPathValidator(req.params)
 
-    console.log('POST - Query Params (car pages):')
+    console.log('POST - Query Params (car page):')
     console.log(req.query)
 
     return res.redirect(expenseUrlRouter.getRedirectUrl(req))

--- a/app/routes/first-time/eligibility/claim/car-hire-details.js
+++ b/app/routes/first-time/eligibility/claim/car-hire-details.js
@@ -6,7 +6,8 @@ module.exports = function (router) {
     UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/car-hire-details', {
       reference: req.params.reference,
-      claim: req.params.claim
+      claim: req.params.claim,
+      params: expenseUrlRouter.parseParams(req.query)
     })
   })
 

--- a/app/routes/first-time/eligibility/claim/car-hire-details.js
+++ b/app/routes/first-time/eligibility/claim/car-hire-details.js
@@ -3,6 +3,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/hire', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/car-hire-details', {
       reference: req.params.reference,
       claim: req.params.claim

--- a/app/routes/first-time/eligibility/claim/expenses.js
+++ b/app/routes/first-time/eligibility/claim/expenses.js
@@ -6,7 +6,8 @@ module.exports = function (router) {
     UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/expenses', {
       reference: req.params.reference,
-      claim: req.params.claim
+      claim: req.params.claim,
+      params: expenseUrlRouter.parseParams(req.query)
     })
   })
 

--- a/app/routes/first-time/eligibility/claim/expenses.js
+++ b/app/routes/first-time/eligibility/claim/expenses.js
@@ -3,6 +3,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claim', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/expenses', {
       reference: req.params.reference,
       claim: req.params.claim

--- a/app/routes/first-time/eligibility/claim/ferry-details.js
+++ b/app/routes/first-time/eligibility/claim/ferry-details.js
@@ -3,6 +3,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/ferry', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/ferry-details', {
       reference: req.params.reference,
       claim: req.params.claim

--- a/app/routes/first-time/eligibility/claim/ferry-details.js
+++ b/app/routes/first-time/eligibility/claim/ferry-details.js
@@ -6,7 +6,8 @@ module.exports = function (router) {
     UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/ferry-details', {
       reference: req.params.reference,
-      claim: req.params.claim
+      claim: req.params.claim,
+      params: expenseUrlRouter.parseParams(req.query)
     })
   })
 

--- a/app/routes/first-time/eligibility/claim/light-refreshment-details.js
+++ b/app/routes/first-time/eligibility/claim/light-refreshment-details.js
@@ -6,7 +6,8 @@ module.exports = function (router) {
     UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/light-refreshment-details', {
       reference: req.params.reference,
-      claim: req.params.claim
+      claim: req.params.claim,
+      params: expenseUrlRouter.parseParams(req.query)
     })
   })
 

--- a/app/routes/first-time/eligibility/claim/light-refreshment-details.js
+++ b/app/routes/first-time/eligibility/claim/light-refreshment-details.js
@@ -3,6 +3,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/refreshment', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/light-refreshment-details', {
       reference: req.params.reference,
       claim: req.params.claim

--- a/app/routes/first-time/eligibility/claim/plane-details.js
+++ b/app/routes/first-time/eligibility/claim/plane-details.js
@@ -3,6 +3,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/plane', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/plane-details', {
       reference: req.params.reference,
       claim: req.params.claim

--- a/app/routes/first-time/eligibility/claim/plane-details.js
+++ b/app/routes/first-time/eligibility/claim/plane-details.js
@@ -6,7 +6,8 @@ module.exports = function (router) {
     UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/plane-details', {
       reference: req.params.reference,
-      claim: req.params.claim
+      claim: req.params.claim,
+      params: expenseUrlRouter.parseParams(req.query)
     })
   })
 

--- a/app/routes/first-time/eligibility/claim/taxi-details.js
+++ b/app/routes/first-time/eligibility/claim/taxi-details.js
@@ -6,7 +6,8 @@ module.exports = function (router) {
     UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/taxi-details', {
       reference: req.params.reference,
-      claim: req.params.claim
+      claim: req.params.claim,
+      params: expenseUrlRouter.parseParams(req.query)
     })
   })
 

--- a/app/routes/first-time/eligibility/claim/taxi-details.js
+++ b/app/routes/first-time/eligibility/claim/taxi-details.js
@@ -3,6 +3,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/taxi', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/taxi-details', {
       reference: req.params.reference,
       claim: req.params.claim

--- a/app/routes/first-time/eligibility/claim/train-details.js
+++ b/app/routes/first-time/eligibility/claim/train-details.js
@@ -3,6 +3,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claim/train', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/train-details', {
       reference: req.params.reference,
       claim: req.params.claim

--- a/app/routes/first-time/eligibility/claim/train-details.js
+++ b/app/routes/first-time/eligibility/claim/train-details.js
@@ -6,7 +6,8 @@ module.exports = function (router) {
     UrlPathValidator(req.params)
     return res.render('first-time/eligibility/claim/train-details', {
       reference: req.params.reference,
-      claim: req.params.claim
+      claim: req.params.claim,
+      params: expenseUrlRouter.parseParams(req.query)
     })
   })
 

--- a/app/routes/first-time/eligibility/new-claim/journey-information.js
+++ b/app/routes/first-time/eligibility/new-claim/journey-information.js
@@ -2,6 +2,7 @@ const UrlPathValidator = require('../../../../services/validators/url-path-valid
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/new-claim/past', function (req, res) {
+    UrlPathValidator(req.params)
     return res.render('first-time/eligibility/new-claim/journey-information', {
       reference: req.params.reference
     })

--- a/app/routes/ux/claim/claim-details.js
+++ b/app/routes/ux/claim/claim-details.js
@@ -1,5 +1,5 @@
 module.exports = function (router) {
-  router.get('/claim-details', function (req, res) {
+  router.get('/first-time-claim/eligibility/:reference/claim/:claim/summary', function (req, res) {
     return res.render('ux/claim/claim-details')
   })
 }

--- a/app/routes/ux/claim/claim-summary.js
+++ b/app/routes/ux/claim/claim-summary.js
@@ -1,5 +1,5 @@
 module.exports = function (router) {
-  router.get('/first-time-claim/eligibility/:reference/claim/:claim/summary', function (req, res) {
+  router.get('/claim-summary', function (req, res) {
     return res.render('ux/claim/claim-summary')
   })
 }

--- a/app/services/routing/expenses-url-router.js
+++ b/app/services/routing/expenses-url-router.js
@@ -18,29 +18,42 @@ module.exports.getRedirectUrl = function (req) {
 
   // TODO should pass either the expense params OR the query params. whichever is set.
   var expenseParams = req.body.expenses
-  // var queryParams = req.params
+  var queryParams = req.params
 
-  return buildUrl(expenseParams, referenceId, claimId)
-}
+  console.log('Expense Params (expenses page):')
+  console.log(expenseParams)
 
-function buildUrl (queryParams, referenceId, claimId) {
-  var params = buildParameterArray(queryParams)
-  return `/first-time-claim/eligibility/${referenceId}/claim/${claimId}/` + getPath(params) + parseParams(params)
-}
+  console.log('Query Params (expense pages):')
+  console.log(queryParams)
 
-function buildParameterArray (queryParams) {
   var params = []
+  if (expenseParams) {
+    params = expenseParams
+  }
+  else if (queryParams) {
+    params = queryParams
+  }
+  return buildUrl(params, referenceId, claimId)
+}
 
-  if (!(queryParams instanceof Array)) {
-    queryParams = [queryParams]
+function buildUrl (params, referenceId, claimId) {
+  var paramsArray = buildParameterArray(params)
+  return `/first-time-claim/eligibility/${referenceId}/claim/${claimId}/` + getPath(paramsArray) + formatParams(paramsArray)
+}
+
+function buildParameterArray (params) {
+  var paramsArray = []
+
+  if (!(params instanceof Array)) {
+    params = [params]
   }
 
-  queryParams.forEach(function (param) {
+  params.forEach(function (param) {
     if (URL_PARAMS.includes(param)) {
-      params.push(param)
+      paramsArray.push(param)
     }
   })
-  return params
+  return paramsArray
 }
 
 function getPath (params) {
@@ -52,13 +65,13 @@ function getPath (params) {
   }
 }
 
-function parseParams (params) {
-  var queryStrings = ''
+function formatParams (params) {
+  var queryString = ''
   if (params) {
-    queryStrings = '?'
+    queryString = '?'
     params.forEach(function (param) {
-      queryStrings += param + '=&'
+      queryString += param + '=&'
     })
   }
-  return queryStrings
+  return queryString
 }

--- a/app/services/routing/expenses-url-router.js
+++ b/app/services/routing/expenses-url-router.js
@@ -82,7 +82,7 @@ function formatParams (params) {
 }
 
 function buildUrl (params, referenceId, claimId) {
-  return `/first-time-claim/eligibility/${referenceId}/claim/${claimId}/` + getPath(params) + formatParamsAndRemoveLeading(params)
+  return `/first-time-claim/eligibility/${referenceId}/claim/${claimId}/${getPath(params)}${formatParamsAndRemoveLeading(params)}`
 }
 
 function isEmptyObject (object) {

--- a/app/services/routing/expenses-url-router.js
+++ b/app/services/routing/expenses-url-router.js
@@ -1,6 +1,5 @@
 const URL_PARAMS = require('../../constants/expenses-url-path-enum')
 
-// TODO: Only add a paramater if we are NOT redirecting to that page.
 // TODO: Need to handle add another journey being selected. Will need to know which page this was selected on.
 // TODO: Split out the URL contruction logic.
 // TODO: Explain what this class does.
@@ -16,7 +15,6 @@ module.exports.getRedirectUrl = function (req) {
   var referenceId = req.params.reference
   var claimId = req.params.claim
 
-  // TODO should pass either the expense params OR the query params. whichever is set.
   var expenseParams = req.body.expenses
   var queryParams = req.query
 
@@ -36,7 +34,7 @@ module.exports.getRedirectUrl = function (req) {
 }
 
 function buildUrl (params, referenceId, claimId) {
-  return `/first-time-claim/eligibility/${referenceId}/claim/${claimId}/` + getPath(params) + formatParams(params)
+  return `/first-time-claim/eligibility/${referenceId}/claim/${claimId}/` + getPath(params) + formatAndHandleLeadingParam(params)
 }
 
 function buildParamArrayFromArray (params) {
@@ -63,20 +61,27 @@ function getPath (params) {
   }
 }
 
+function formatAndHandleLeadingParam (params) {
+  // TODO: Do this only if the user did NOT set add another journey to true.
+  // Remove the first param as we will be redirecting to this page.
+  params.shift()
+  return formatParams(params)
+}
+
 function formatParams (params) {
   var queryString = ''
-  if (params) {
+  if (params && params.length > 0) {
     queryString = '?'
     params.forEach(function (param) {
       queryString += param + '=&'
     })
   }
-  return queryString.replace(/&$/, "")
+  return queryString.replace(/&$/, '')
 }
 
-function buildParamArrayFromObject(params) {
+function buildParamArrayFromObject (params) {
   var paramsArray = []
-  for(var param in params) {
+  for (var param in params) {
     paramsArray.push(param)
   }
   return paramsArray

--- a/app/services/routing/expenses-url-router.js
+++ b/app/services/routing/expenses-url-router.js
@@ -65,7 +65,7 @@ function getPath (params) {
 }
 
 // Remove the first param as we will be redirecting to this page.
-function formatAndHandleLeadingParam (params) {
+function formatParamsAndRemoveLeading (params) {
   params.shift()
   return formatParams(params)
 }
@@ -82,7 +82,7 @@ function formatParams (params) {
 }
 
 function buildUrl (params, referenceId, claimId) {
-  return `/first-time-claim/eligibility/${referenceId}/claim/${claimId}/` + getPath(params) + formatAndHandleLeadingParam(params)
+  return `/first-time-claim/eligibility/${referenceId}/claim/${claimId}/` + getPath(params) + formatParamsAndRemoveLeading(params)
 }
 
 function isEmptyObject (object) {

--- a/app/services/routing/expenses-url-router.js
+++ b/app/services/routing/expenses-url-router.js
@@ -3,7 +3,7 @@ const URL_PARAMS = require('../../constants/expenses-url-path-enum')
 // TODO: Split out the URL contruction logic.
 // TODO: Explain what this class does.
 
-const POST_EXPENSES_URL = 'summary'
+const POST_EXPENSES_PATH = 'summary'
 
 module.exports.parseParams = function (queryParams) {
   return formatParams(buildParamsArrayFromObject(queryParams))
@@ -60,7 +60,7 @@ function getPath (params) {
   if (firstParam) {
     return firstParam
   } else {
-    return POST_EXPENSES_URL
+    return POST_EXPENSES_PATH
   }
 }
 

--- a/app/services/routing/expenses-url-router.js
+++ b/app/services/routing/expenses-url-router.js
@@ -28,19 +28,18 @@ module.exports.getRedirectUrl = function (req) {
 
   var params = []
   if (expenseParams) {
-    params = expenseParams
+    params = buildParamArrayFromArray(expenseParams)
   } else if (queryParams) {
-    params = queryParams
+    params = buildParamArrayFromObject(queryParams)
   }
   return buildUrl(params, referenceId, claimId)
 }
 
 function buildUrl (params, referenceId, claimId) {
-  var paramsArray = buildParameterArray(params)
-  return `/first-time-claim/eligibility/${referenceId}/claim/${claimId}/` + getPath(paramsArray) + formatParams(paramsArray)
+  return `/first-time-claim/eligibility/${referenceId}/claim/${claimId}/` + getPath(params) + formatParams(params)
 }
 
-function buildParameterArray (params) {
+function buildParamArrayFromArray (params) {
   var paramsArray = []
 
   if (!(params instanceof Array)) {
@@ -72,5 +71,17 @@ function formatParams (params) {
       queryString += param + '=&'
     })
   }
-  return queryString
+  return queryString.replace(/&$/, "")
+}
+
+function buildParamArrayFromObject(params) {
+  var paramsArray = []
+  for(var param in params) {
+    paramsArray.push(param)
+  }
+  return paramsArray
+}
+
+module.exports.parseParams = function (queryParams) {
+  return formatParams(buildParamArrayFromObject(queryParams))
 }

--- a/app/services/routing/expenses-url-router.js
+++ b/app/services/routing/expenses-url-router.js
@@ -18,19 +18,18 @@ module.exports.getRedirectUrl = function (req) {
 
   // TODO should pass either the expense params OR the query params. whichever is set.
   var expenseParams = req.body.expenses
-  var queryParams = req.params
+  var queryParams = req.query
 
-  console.log('Expense Params (expenses page):')
+  console.log('ROUTER - Expense Params:')
   console.log(expenseParams)
 
-  console.log('Query Params (expense pages):')
+  console.log('ROUTER - Query Params:')
   console.log(queryParams)
 
   var params = []
   if (expenseParams) {
     params = expenseParams
-  }
-  else if (queryParams) {
+  } else if (queryParams) {
     params = queryParams
   }
   return buildUrl(params, referenceId, claimId)

--- a/app/views/first-time/eligibility/claim/accommodation-details.html
+++ b/app/views/first-time/eligibility/claim/accommodation-details.html
@@ -21,7 +21,7 @@
 
       <p>Before claiming assistance for a Accommodation, you must contact the Assisted Prison Visits Unit.</p>
 
-      <form action="/first-time-claim/eligibility/{{ reference }}/claim/{{ claim }}/accommodation" method="post">
+      <form action="/first-time-claim/eligibility/{{reference}}/claim/{{claim}}/accommodation{{params}}" method="post">
 
         <div class="form-group">
           <label for="number-of-nights" class="form-label-bold">Number of nights</label>

--- a/app/views/first-time/eligibility/claim/bus-details.html
+++ b/app/views/first-time/eligibility/claim/bus-details.html
@@ -79,8 +79,7 @@
               <label for="add-another-journey" class="block-label">
                 <input id="add-another-journey"
                        type="checkbox"
-                       name="add-another-journey"
-                       value="yes">
+                       name="add-another-journey">
                 Add another bus journey
               </label>
 

--- a/app/views/first-time/eligibility/claim/bus-details.html
+++ b/app/views/first-time/eligibility/claim/bus-details.html
@@ -19,7 +19,7 @@
         Add bus journey information
       </h2>
 
-      <form action="/first-time-claim/eligibility/{{ reference }}/claim/{{ claim }}/bus" method="post">
+      <form action="/first-time-claim/eligibility/{{reference}}/claim/{{claim}}/bus{{params}}" method="post">
 
         <div class="form-group">
           <label for="from" class="form-label-bold">From</label>

--- a/app/views/first-time/eligibility/claim/car-details.html
+++ b/app/views/first-time/eligibility/claim/car-details.html
@@ -28,7 +28,7 @@
         You may also add toll or parking charges you had to pay.
       </p>
 
-      <form action="/first-time-claim/eligibility/{{ reference }}/claim/{{ claim }}/car" method="post">
+      <form action="/first-time-claim/eligibility/{{reference}}/claim/{{claim}}/car{{params}}" method="post">
 
         <div class="form-group">
           <label class="form-label-bold">From</label>

--- a/app/views/first-time/eligibility/claim/car-hire-details.html
+++ b/app/views/first-time/eligibility/claim/car-hire-details.html
@@ -24,7 +24,7 @@
 
       <p>A mileage allowance of 13p per mile will also be paid based on the shortest return journey. </p>
 
-      <form action="/first-time-claim/eligibility/{{ reference }}/claim/{{ claim }}/hire" method="post">
+      <form action="/first-time-claim/eligibility/{{reference}}/claim/{{claim}}/hire{{params}}" method="post">
 
         <div class="form-group">
           <label for="number-of-days" class="form-label-bold">Number of days</label>

--- a/app/views/first-time/eligibility/claim/ferry-details.html
+++ b/app/views/first-time/eligibility/claim/ferry-details.html
@@ -25,7 +25,7 @@
       <p>When you are also claiming for a car journey, the ferry mileage will be deducted from your car mileage
         claim.</p>
 
-      <form action="/first-time-claim/eligibility/{{ reference }}/claim/{{ claim }}/ferry" method="post">
+      <form action="/first-time-claim/eligibility/{{reference}}/claim/{{claim}}/ferry{{params}}" method="post">
 
         <div class="form-group">
           <label for="from" class="form-label-bold">From</label>

--- a/app/views/first-time/eligibility/claim/light-refreshment-details.html
+++ b/app/views/first-time/eligibility/claim/light-refreshment-details.html
@@ -27,7 +27,7 @@
 
       <p>Receipts should be held in case these are needed later on.</p>
 
-      <form action="/first-time-claim/eligibility/{{ reference }}/claim/{{ claim }}/refreshment" method="post">
+      <form action="/first-time-claim/eligibility/{{reference}}/claim/{{claim}}/refreshment{{params}}" method="post">
 
         <div class="form-group">
 

--- a/app/views/first-time/eligibility/claim/plane-details.html
+++ b/app/views/first-time/eligibility/claim/plane-details.html
@@ -23,7 +23,7 @@
 
       <p>Claims that include air travel require approval before you travel, by the Assisted Prison Visits Unit.</p>
 
-      <form action="/first-time-claim/eligibility/{{ reference }}/claim/{{ claim }}/plane" method="post">
+      <form action="/first-time-claim/eligibility/{{reference}}/claim/{{claim}}/plane{{params}}" method="post">
 
         <div class="form-group">
           <label for="from" class="form-label-bold">From</label>

--- a/app/views/first-time/eligibility/claim/plane-details.html
+++ b/app/views/first-time/eligibility/claim/plane-details.html
@@ -83,8 +83,7 @@
               <label for="add-another-journey" class="block-label">
                 <input id="add-another-journey"
                        type="checkbox"
-                       name="add-another-journey"
-                       value="yes">
+                       name="add-another-journey">
                 Add another plane journey
               </label>
 

--- a/app/views/first-time/eligibility/claim/taxi-details.html
+++ b/app/views/first-time/eligibility/claim/taxi-details.html
@@ -67,8 +67,7 @@
               <label for="add-another-taxi" class="block-label">
                 <input id="add-another-taxi"
                        type="radio"
-                       name="add-another-journey"
-                       value="yes">
+                       name="add-another-journey">
                 Add another taxi journey
               </label>
 

--- a/app/views/first-time/eligibility/claim/taxi-details.html
+++ b/app/views/first-time/eligibility/claim/taxi-details.html
@@ -27,7 +27,7 @@
       <p>You will need to enter a different taxi journey for each taxi receipt you hold. So a return taxi journey would
         require two separate taxi journey claims to be made (assuming you hold two receipts).</p>
 
-      <form action="/first-time-claim/eligibility/{{ reference }}/claim/{{ claim }}/taxi" method="post">
+      <form action="/first-time-claim/eligibility/{{reference}}/claim/{{claim}}/taxi{{params}}" method="post">
 
         <div class="form-group">
           <label for="from" class="form-label-bold">From</label>

--- a/app/views/first-time/eligibility/claim/train-details.html
+++ b/app/views/first-time/eligibility/claim/train-details.html
@@ -19,7 +19,7 @@
         Add train journey information
       </h2>
 
-      <form action="/first-time-claim/eligibility/{{ reference }}/claim/{{ claim }}/train" method="post">
+      <form action="/first-time-claim/eligibility/{{reference}}/claim/{{claim}}/train{{params}}" method="post">
 
         <div class="form-group">
           <label for="from" class="form-label-bold">From</label>

--- a/app/views/first-time/eligibility/claim/train-details.html
+++ b/app/views/first-time/eligibility/claim/train-details.html
@@ -79,8 +79,7 @@
               <label for="add-another-journey" class="block-label">
                 <input id="add-another-journey"
                        type="checkbox"
-                       name="add-another-journey"
-                       value="yes">
+                       name="add-another-journey">
                 Add another train journey
               </label>
 

--- a/app/views/ux/claim/claim-details.html
+++ b/app/views/ux/claim/claim-details.html
@@ -93,7 +93,7 @@
         </label>
         <textarea id="additional-info" class="form-control full"></textarea>
         <br>
-        <a class="button">Send</a>
+        <a id="claim-summary-submit" class="button">Send</a>
       </div>
     </div>
 

--- a/test/e2e/spec.js
+++ b/test/e2e/spec.js
@@ -84,7 +84,7 @@ describe('First time claim flow', () => {
       .waitForExist('#bus-details-submit')
       .setValue('#from', 'Euston')
       .setValue('#to', 'Birmingham New Street')
-      .click('#return-yes')
+      .click('#return-no')
       .setValue('#cost', '20')
       .click('#add-another-journey')
       .click('#bus-details-submit')
@@ -93,7 +93,7 @@ describe('First time claim flow', () => {
       .waitForExist('#bus-details-submit')
       .setValue('#from', 'Birmingham New Street')
       .setValue('#to', 'Euston')
-      .click('#return-yes')
+      .click('#return-no')
       .setValue('#cost', '20')
       .click('#bus-details-submit')
 

--- a/test/e2e/spec.js
+++ b/test/e2e/spec.js
@@ -71,5 +71,39 @@ describe('First time claim flow', () => {
 
       // Expense
       .waitForExist('#expenses-submit')
+      .click('#car')
+      .click('#bus')
+      .click('#refreshment')
+      .click('#expenses-submit')
+
+      // Car
+      .waitForExist('#car-details-submit')
+      .click('#car-details-submit')
+
+      // Bus #1
+      .waitForExist('#bus-details-submit')
+      .setValue('#from', 'Euston')
+      .setValue('#to', 'Birmingham New Street')
+      .click('#return-yes')
+      .setValue('#cost', '20')
+      .click('#add-another-journey')
+      .click('#bus-details-submit')
+
+      // Bus #2 (Add Another Journey)
+      .waitForExist('#bus-details-submit')
+      .setValue('#from', 'Birmingham New Street')
+      .setValue('#to', 'Euston')
+      .click('#return-yes')
+      .setValue('#cost', '20')
+      .click('#bus-details-submit')
+
+      // Light Refreshment
+      .waitForExist('#light-refreshment-details-submit')
+      .click('#travel-time-over-five')
+      .setValue('#cost', '7.99')
+      .click('#light-refreshment-details-submit')
+
+      // Claim Details
+      .waitForExist('#claim-summary-submit')
   })
 })


### PR DESCRIPTION
This is a parital solution for #664.

**Url Router:**
- The leading param (i.e. the next page to redirect to) is now removed each time the Url Router is called such that we tend towards zero paramaters and thus redirect to claim-summary. 
- We now redirect to the origin url if the claimant selects add another journey.
- Now striping out trailing ampersands
- Prevent trailing question marks from being appended to the url.

**Routes:**
- The GET routes now pass the query params to the HTML page.
- Added the Url Validator to each of the GET routes.

**HTML:**
- The expense HTML pages now pass the params to the POST route so that they reach the next page in the chain.

**Tests:**
- Updated end-to-end test to extend to the claim-summary page. Includes calling three expense pages and selecting to add an additional journey on one of them.

**Remaining:**
- Ensure all error cases are handled.
- Split the URL construction logic out into another file.
- Unit tests for the URL construction and routing logic.

## Checklist

- [ ] Unit tests
- [x] End-to-End tests
- [ ] Code coverage checked
- [x] Coding standards
- [x] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated