### PR TITLE
Chore/add saucelabs mobile tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm test                        # checks code against standard JS and runs mocha
 npm run-script test-coverage    # unit tests and generates code coverage using Istanbul
 npm run-script test-unit        # unit tests
 npm run-script test-integration # integration tests
-npm run-script test-e2e         # e2e tests using selenium standalone against local
+npm run-script test-e2e         # e2e tests using selenium standalone against local application (must already be running)
 ```
 
 Run e2e tests with [saucelabs](https://saucelabs.com)
@@ -63,6 +63,9 @@ export SAUCE_BASEURL='http://localhost:3000' # proxy url for sauce connect
 
 npm run-script test-e2e-ie8
 npm run-script test-e2e-firefox
+npm run-script test-e2e-ios
+npm run-script test-e2e-android
+
 ```
 
 ## Database

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "test-e2e-firefox": "wdio test/wdio.conf.sauce.firefox.js",
     "test-e2e-ie8-jenkins": "wdio test/wdio.conf.sauce.ie8.jenkins.js",
     "test-e2e-firefox-jenkins": "wdio test/wdio.conf.sauce.firefox.jenkins.js",
+    "test-e2e-ios": "wdio test/wdio.conf.sauce.ios.js",
+    "test-e2e-android": "wdio test/wdio.conf.sauce.android.js",
     "migrations": "knex migrate:latest --env migrations"
   },
   "standard": {

--- a/test/e2e/spec.js
+++ b/test/e2e/spec.js
@@ -87,6 +87,9 @@ describe('First time claim flow', () => {
       .click('#add-another-journey')
       .click('#bus-details-submit')
 
+      // Allow second bus page to load
+      .pause(1000)
+
       // Bus #2 (add another journey)
       .waitForExist('#bus-details-submit')
       .setValue('#from-input', 'Birmingham New Street')

--- a/test/e2e/spec.js
+++ b/test/e2e/spec.js
@@ -88,7 +88,7 @@ describe('First time claim flow', () => {
       .click('#bus-details-submit')
 
       // Allow second bus page to load
-      .pause(1000)
+      .pause(3000)
 
       // Bus #2 (add another journey)
       .waitForExist('#bus-details-submit')

--- a/test/wdio.conf.sauce.android.js
+++ b/test/wdio.conf.sauce.android.js
@@ -19,8 +19,8 @@ exports.config = {
   logLevel: 'verbose',
   coloredLogs: true,
   screenshotPath: './errorShots/',
-  waitforTimeout: 180000,
-  connectionRetryTimeout: 180000,
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 90000,
   connectionRetryCount: 3,
   framework: 'mocha',
   mochaOpts: {

--- a/test/wdio.conf.sauce.android.js
+++ b/test/wdio.conf.sauce.android.js
@@ -1,0 +1,30 @@
+exports.config = {
+  specs: ['./test/e2e/**/*.js'],
+  exclude: [],
+  maxInstances: 1,
+  services: ['sauce'],
+  user: process.env.SAUCE_USERNAME,
+  key: process.env.SAUCE_ACCESS_KEY,
+  baseUrl: process.env.SAUCE_BASEURL || 'http://localhost:3000',
+  sauceConnect: true,
+  capabilities: [{
+    maxInstances: 1,
+    platformName: 'Android',
+    platformVersion: '5.1',
+    browserName: 'Browser',
+    deviceName: 'Android Emulator',
+    deviceOrientation: 'portrait'
+  }],
+  sync: false,
+  logLevel: 'verbose',
+  coloredLogs: true,
+  screenshotPath: './errorShots/',
+  waitforTimeout: 180000,
+  connectionRetryTimeout: 180000,
+  connectionRetryCount: 3,
+  framework: 'mocha',
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 500000
+  }
+}

--- a/test/wdio.conf.sauce.ios.js
+++ b/test/wdio.conf.sauce.ios.js
@@ -1,0 +1,30 @@
+exports.config = {
+  specs: ['./test/e2e/**/*.js'],
+  exclude: [],
+  maxInstances: 1,
+  services: ['sauce'],
+  user: process.env.SAUCE_USERNAME,
+  key: process.env.SAUCE_ACCESS_KEY,
+  baseUrl: process.env.SAUCE_BASEURL || 'http://localhost:3000',
+  sauceConnect: true,
+  capabilities: [{
+    maxInstances: 1,
+    platformName: 'iOS',
+    platformVersion: '9.0',
+    browserName: 'Safari',
+    deviceName: 'iPhone 6 Simulator',
+    deviceOrientation: 'portrait'
+  }],
+  sync: false,
+  logLevel: 'verbose',
+  coloredLogs: true,
+  screenshotPath: './errorShots/',
+  waitforTimeout: 300000,
+  connectionRetryTimeout: 300000,
+  connectionRetryCount: 3,
+  framework: 'mocha',
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 800000
+  }
+}

--- a/test/wdio.conf.sauce.ios.js
+++ b/test/wdio.conf.sauce.ios.js
@@ -19,8 +19,8 @@ exports.config = {
   logLevel: 'verbose',
   coloredLogs: true,
   screenshotPath: './errorShots/',
-  waitforTimeout: 300000,
-  connectionRetryTimeout: 300000,
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 90000,
   connectionRetryCount: 3,
   framework: 'mocha',
   mochaOpts: {

--- a/test/wdio.conf.sauce.ios.js
+++ b/test/wdio.conf.sauce.ios.js
@@ -10,9 +10,9 @@ exports.config = {
   capabilities: [{
     maxInstances: 1,
     platformName: 'iOS',
-    platformVersion: '9.0',
+    platformVersion: '9.1',
     browserName: 'Safari',
-    deviceName: 'iPhone 6 Simulator',
+    deviceName: 'iPhone 6s Simulator',
     deviceOrientation: 'portrait'
   }],
   sync: false,


### PR DESCRIPTION
chore - add saucelabs mobile tests

- iPhone 6s Simulator / iOS 9.1 / Safari / [link to saucelabs test run](https://saucelabs.com/beta/tests/bdbf031d2a2644cf9e00088d339957dc)
- Android Emulator / 5.1 / [link to saucelabs test run](https://saucelabs.com/beta/tests/c6bbcdd163c54a8b8c438e13626fbd20)

## Checklist

- [ ] Unit tests
- [x] End-to-End tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
