### PR TITLE
Added unit tests for the expense routes

### DIFF
--- a/app/routes/first-time/about-the-prisoner.js
+++ b/app/routes/first-time/about-the-prisoner.js
@@ -4,7 +4,7 @@ const UrlPathValidator = require('../../services/validators/url-path-validator')
 
 module.exports = function (router) {
   router.get('/first-time/:dob/:relationship/:benefit', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/about-the-prisoner', {
       dob: req.params.dob,
       relationship: req.params.relationship,
@@ -13,7 +13,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time/:dob/:relationship/:benefit', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     var validationErrors = validator(req.body)
     var dob = req.params.dob

--- a/app/routes/first-time/about-you.js
+++ b/app/routes/first-time/about-you.js
@@ -4,7 +4,7 @@ const insertVisitor = require('../../services/data/insert-visitor')
 
 module.exports = function (router) {
   router.get('/first-time/:dob/:relationship/:benefit/:reference', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/about-you', {
       dob: req.params.dob,
       relationship: req.params.relationship,
@@ -14,7 +14,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time/:dob/:relationship/:benefit/:reference', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     var validationErrors = aboutYouValidator(req.body)
     var dob = req.params.dob

--- a/app/routes/first-time/benefits.js
+++ b/app/routes/first-time/benefits.js
@@ -3,7 +3,7 @@ const UrlPathValidator = require('../../services/validators/url-path-validator')
 
 module.exports = function (router) {
   router.get('/first-time/:dob/:relationship', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/benefits', {
       dob: req.params.dob,
       relationship: req.params.relationship
@@ -11,7 +11,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time/:dob/:relationship', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     var dob = req.params.dob
     var relationship = req.params.relationship

--- a/app/routes/first-time/eligibility/claim/accommodation-details.js
+++ b/app/routes/first-time/eligibility/claim/accommodation-details.js
@@ -6,7 +6,7 @@ const insertExpense = require('../../../../services/data/insert-expense')
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/accommodation', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/claim/accommodation-details', {
       reference: req.params.reference,
       claimId: req.params.claimId,
@@ -15,7 +15,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/accommodation', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     try {
       var expense = new AccommodationExpense(
@@ -24,7 +24,7 @@ module.exports = function (router) {
         req.body.duration
       )
 
-      insertExpense(expense)
+      insertExpense.insert(expense)
         .then(function () {
           return res.redirect(expenseUrlRouter.getRedirectUrl(req))
         })

--- a/app/routes/first-time/eligibility/claim/bank-account-details.js
+++ b/app/routes/first-time/eligibility/claim/bank-account-details.js
@@ -6,7 +6,7 @@ const UrlPathValidator = require('../../../../services/validators/url-path-valid
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/bank-account-details', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/claim/bank-account-details', {
       reference: req.params.reference,
       claimId: req.params.claimId
@@ -14,7 +14,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/bank-account-details', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     try {
       var bankAccountDetails = new BankAccountDetails(req.body.AccountNumber, req.body.SortCode)
       insertBankAccountDetailsForClaim(req.params.claimId, bankAccountDetails)

--- a/app/routes/first-time/eligibility/claim/bus-details.js
+++ b/app/routes/first-time/eligibility/claim/bus-details.js
@@ -6,7 +6,7 @@ const insertExpense = require('../../../../services/data/insert-expense')
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/bus', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/claim/bus-details', {
       reference: req.params.reference,
       claimId: req.params.claimId,
@@ -15,7 +15,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/bus', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     try {
       var expense = new BusExpense(
@@ -26,7 +26,7 @@ module.exports = function (router) {
         req.body['return-journey']
       )
 
-      insertExpense(expense)
+      insertExpense.insert(expense)
         .then(function () {
           return res.redirect(expenseUrlRouter.getRedirectUrl(req))
         })

--- a/app/routes/first-time/eligibility/claim/car-details.js
+++ b/app/routes/first-time/eligibility/claim/car-details.js
@@ -7,8 +7,8 @@ const insertCarExpenses = require('../../../../services/data/insert-car-expenses
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/car', function (req, res) {
-    UrlPathValidator(req.params)
-    getTravellingFromAndTo(req.params.reference)
+    UrlPathValidator.validate(req.params)
+    getTravellingFromAndTo.get(req.params.reference)
       .then(function (result) {
         return res.render('first-time/eligibility/claim/car-details', {
           reference: req.params.reference,
@@ -20,7 +20,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/car', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     try {
       var expense = new CarExpense(
@@ -33,7 +33,7 @@ module.exports = function (router) {
         req.body[ 'parking-charge-cost' ]
       )
 
-      insertCarExpenses(expense)
+      insertCarExpenses.insert(expense)
         .then(function () {
           return res.redirect(expenseUrlRouter.getRedirectUrl(req))
         })

--- a/app/routes/first-time/eligibility/claim/car-hire-details.js
+++ b/app/routes/first-time/eligibility/claim/car-hire-details.js
@@ -6,7 +6,7 @@ const insertExpense = require('../../../../services/data/insert-expense')
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/hire', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/claim/car-hire-details', {
       reference: req.params.reference,
       claimId: req.params.claimId,
@@ -15,7 +15,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/hire', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     try {
       var expense = new HireExpense(
@@ -26,7 +26,7 @@ module.exports = function (router) {
         req.body.duration
       )
 
-      insertExpense(expense)
+      insertExpense.insert(expense)
         .then(function () {
           return res.redirect(expenseUrlRouter.getRedirectUrl(req))
         })

--- a/app/routes/first-time/eligibility/claim/claim-summary.js
+++ b/app/routes/first-time/eligibility/claim/claim-summary.js
@@ -7,7 +7,7 @@ const benefitsEnum = require('../../../../constants/benefits-enum')
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/summary', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     getIndividualClaimDetails(req.params.claimId)
       .then(function (claimDetails) {
@@ -24,12 +24,12 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/summary', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.redirect(`/first-time-claim/eligibility/${req.params.reference}/claim/${req.params.claimId}/bank-account-details`)
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/summary/remove/:claimExpenseId', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     removeClaimExpense(req.params.claimId, req.params.claimExpenseId)
       .then(function (claimDetails) {

--- a/app/routes/first-time/eligibility/claim/expenses.js
+++ b/app/routes/first-time/eligibility/claim/expenses.js
@@ -4,7 +4,7 @@ const expenseUrlRouter = require('../../../../services/routing/expenses-url-rout
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/claim/expenses', {
       reference: req.params.reference,
       claimId: req.params.claimId
@@ -12,7 +12,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     var validationErrors = ExpensesValidator(req.body)
     if (validationErrors) {
       return res.status(400).render('first-time/eligibility/claim/expenses', {

--- a/app/routes/first-time/eligibility/claim/ferry-details.js
+++ b/app/routes/first-time/eligibility/claim/ferry-details.js
@@ -6,7 +6,7 @@ const insertExpense = require('../../../../services/data/insert-expense')
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/ferry', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/claim/ferry-details', {
       reference: req.params.reference,
       claimId: req.params.claimId,
@@ -15,7 +15,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/ferry', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     try {
       var expense = new FerryExpense(
@@ -27,7 +27,7 @@ module.exports = function (router) {
         req.body['ticket-type']
       )
 
-      insertExpense(expense)
+      insertExpense.insert(expense)
         .then(function () {
           return res.redirect(expenseUrlRouter.getRedirectUrl(req))
         })

--- a/app/routes/first-time/eligibility/claim/light-refreshment-details.js
+++ b/app/routes/first-time/eligibility/claim/light-refreshment-details.js
@@ -6,7 +6,7 @@ const insertExpense = require('../../../../services/data/insert-expense')
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/refreshment', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/claim/light-refreshment-details', {
       reference: req.params.reference,
       claimId: req.params.claimId,
@@ -15,7 +15,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/refreshment', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     try {
       var expense = new RefreshmentExpense(
@@ -24,7 +24,7 @@ module.exports = function (router) {
         req.body['travel-time']
       )
 
-      insertExpense(expense)
+      insertExpense.insert(expense)
         .then(function () {
           return res.redirect(expenseUrlRouter.getRedirectUrl(req))
         })

--- a/app/routes/first-time/eligibility/claim/plane-details.js
+++ b/app/routes/first-time/eligibility/claim/plane-details.js
@@ -6,7 +6,7 @@ const insertExpense = require('../../../../services/data/insert-expense')
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/plane', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/claim/plane-details', {
       reference: req.params.reference,
       claimId: req.params.claimId,
@@ -15,7 +15,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/plane', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     try {
       var expense = new PlaneExpense(
@@ -26,7 +26,7 @@ module.exports = function (router) {
         req.body['return-journey']
       )
 
-      insertExpense(expense)
+      insertExpense.insert(expense)
         .then(function () {
           return res.redirect(expenseUrlRouter.getRedirectUrl(req))
         })

--- a/app/routes/first-time/eligibility/claim/taxi-details.js
+++ b/app/routes/first-time/eligibility/claim/taxi-details.js
@@ -6,7 +6,7 @@ const insertExpense = require('../../../../services/data/insert-expense')
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/taxi', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/claim/taxi-details', {
       reference: req.params.reference,
       claimId: req.params.claimId,
@@ -15,7 +15,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/taxi', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     try {
       var expense = new TaxiExpense(
@@ -25,7 +25,7 @@ module.exports = function (router) {
         req.body.to
       )
 
-      insertExpense(expense)
+      insertExpense.insert(expense)
         .then(function () {
           return res.redirect(expenseUrlRouter.getRedirectUrl(req))
         })

--- a/app/routes/first-time/eligibility/claim/train-details.js
+++ b/app/routes/first-time/eligibility/claim/train-details.js
@@ -6,7 +6,7 @@ const insertExpense = require('../../../../services/data/insert-expense')
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/claim/:claimId/train', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/claim/train-details', {
       reference: req.params.reference,
       claimId: req.params.claimId,
@@ -15,7 +15,7 @@ module.exports = function (router) {
   })
 
   router.post('/first-time-claim/eligibility/:reference/claim/:claimId/train', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     try {
       var expense = new TrainExpense(
@@ -26,7 +26,7 @@ module.exports = function (router) {
         req.body['return-journey']
       )
 
-      insertExpense(expense)
+      insertExpense.insert(expense)
         .then(function () {
           return res.redirect(expenseUrlRouter.getRedirectUrl(req))
         })

--- a/app/routes/first-time/eligibility/new-claim/future-or-past-visit.js
+++ b/app/routes/first-time/eligibility/new-claim/future-or-past-visit.js
@@ -2,14 +2,14 @@ const UrlPathValidator = require('../../../../services/validators/url-path-valid
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/new-claim', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/new-claim/future-or-past-visit', {
       reference: req.params.reference
     })
   })
 
   router.post('/first-time-claim/eligibility/:reference/new-claim', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.redirect(`/first-time-claim/eligibility/${req.params.reference}/new-claim/past`)
   })
 }

--- a/app/routes/first-time/eligibility/new-claim/journey-information.js
+++ b/app/routes/first-time/eligibility/new-claim/journey-information.js
@@ -5,14 +5,14 @@ const insertFirstTimeClaim = require('../../../../services/data/insert-first-tim
 
 module.exports = function (router) {
   router.get('/first-time-claim/eligibility/:reference/new-claim/past', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/eligibility/new-claim/journey-information', {
       reference: req.params.reference
     })
   })
 
   router.post('/first-time-claim/eligibility/:reference/new-claim/past', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     try {
       var firstTimeClaim = new FirstTimeClaim(

--- a/app/routes/first-time/prisoner-relationship.js
+++ b/app/routes/first-time/prisoner-relationship.js
@@ -3,14 +3,14 @@ const UrlPathValidator = require('../../services/validators/url-path-validator')
 
 module.exports = function (router) {
   router.get('/first-time/:dob', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
     return res.render('first-time/prisoner-relationship', {
       dob: req.params.dob
     })
   })
 
   router.post('/first-time/:dob', function (req, res) {
-    UrlPathValidator(req.params)
+    UrlPathValidator.validate(req.params)
 
     var relationship = req.body.relationship
     var dob = req.params.dob

--- a/app/services/data/get-travelling-from-and-to.js
+++ b/app/services/data/get-travelling-from-and-to.js
@@ -1,7 +1,7 @@
 const config = require('../../../knexfile').extweb
 const knex = require('knex')(config)
 
-module.exports = function (reference) {
+module.exports.get = function (reference) {
   return knex('Visitor')
     .join('Prisoner', 'Visitor.Reference', '=', 'Prisoner.Reference')
     .where('Visitor.Reference', reference)

--- a/app/services/data/insert-car-expenses.js
+++ b/app/services/data/insert-car-expenses.js
@@ -1,6 +1,6 @@
 const insertExpense = require('../../services/data/insert-expense')
 
-module.exports = function (expense) {
+module.exports.insert = function (expense) {
   return insert(expense)
     .then(function () {
       return insert(expense.tollExpense)
@@ -12,6 +12,6 @@ module.exports = function (expense) {
 
 function insert (expense) {
   if (expense) {
-    return insertExpense(expense)
+    return insertExpense.insert(expense)
   }
 }

--- a/app/services/data/insert-expense.js
+++ b/app/services/data/insert-expense.js
@@ -2,7 +2,7 @@ const config = require('../../../knexfile').extweb
 const knex = require('knex')(config)
 const ExpenseBase = require('../../services/domain/expenses/base-expense')
 
-module.exports = function (expense) {
+module.exports.insert = function (expense) {
   if (!(expense instanceof ExpenseBase)) {
     throw new Error('Provided object is not an instance of the expected class')
   }

--- a/app/services/validators/url-path-validator.js
+++ b/app/services/validators/url-path-validator.js
@@ -24,6 +24,6 @@ class UrlPathValidator {
   }
 }
 
-module.exports = function (data) {
+module.exports.validate = function (data) {
   return UrlPathValidator.validate(data)
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
       "before",
       "beforeEach",
       "after",
+      "afterEach",
       "it",
       "browser"
     ]

--- a/test/helpers/routes/route-helper.js
+++ b/test/helpers/routes/route-helper.js
@@ -1,0 +1,16 @@
+const mockViewEngine = require('../../unit/routes/mock-view-engine')
+const express = require('express')
+const bodyParser = require('body-parser')
+const app = express()
+
+const VIEWS_DIRECTORY = '../../../app/views'
+
+module.exports.VALID_REFERENCE = 'A123456'
+module.exports.VALID_CLAIM_ID = '1'
+
+module.exports.build = function (route) {
+  app.use(bodyParser.json())
+  route(app)
+  mockViewEngine(app, VIEWS_DIRECTORY)
+  return app
+}

--- a/test/unit/routes/first-time/eligibility/claim/test-accommodation-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-accommodation-details.js
@@ -1,0 +1,84 @@
+const supertest = require('supertest')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const route = require('../../../../../../app/routes/first-time/eligibility/claim/accommodation-details')
+const app = routeHelper.build(route)
+
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+const expenseUrlRouter = require('../../../../../../app/services/routing/expenses-url-router')
+const insertExpense = require('../../../../../../app/services/data/insert-expense')
+
+describe('routes/first-time/eligibility/claim/accommodation', function () {
+  const VALID_ROUTE = `/first-time-claim/eligibility/${routeHelper.VALID_REFERENCE}/claim/${routeHelper.VALID_CLAIM_ID}/accommodation`
+  const VALID_BODY = {
+    'cost': '10',
+    'duration': '1'
+  }
+
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe(`GET ${VALID_ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(200)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should call parseParams', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+        })
+    })
+  })
+
+  describe(`POST ${VALID_ROUTE}`, function () {
+    it('should respond with a 200 if expected body parameters are set', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
+      var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(VALID_BODY)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+          sinon.assert.calledOnce(stubInsertExpense)
+        })
+        .expect(302)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(400)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-accommodation-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-accommodation-details.js
@@ -28,14 +28,14 @@ describe('routes/first-time/eligibility/claim/accommodation', function () {
 
   describe(`GET ${VALID_ROUTE}`, function () {
     it('should respond with a 200', function () {
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(200)
     })
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -44,7 +44,7 @@ describe('routes/first-time/eligibility/claim/accommodation', function () {
 
     it('should call parseParams', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(expenseUrlRouterSpy)
@@ -56,7 +56,7 @@ describe('routes/first-time/eligibility/claim/accommodation', function () {
     it('should respond with a 200 if expected body parameters are set', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
       var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(VALID_BODY)
         .expect(function () {
@@ -68,7 +68,7 @@ describe('routes/first-time/eligibility/claim/accommodation', function () {
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -76,7 +76,7 @@ describe('routes/first-time/eligibility/claim/accommodation', function () {
     })
 
     it('should respond with a 400 if domain object validation fails.', function () {
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(400)
     })

--- a/test/unit/routes/first-time/eligibility/claim/test-bank-account-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-bank-account-details.js
@@ -60,7 +60,7 @@ describe('routes/first-time/eligibility/claim/bank-account-details', function ()
 
     it('should call the URL Path Validator ', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return request
+      request
         .get(`/first-time-claim/eligibility/${reference}/claim/${claimId}/bank-account-details`)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -103,7 +103,7 @@ describe('routes/first-time/eligibility/claim/bank-account-details', function ()
     it('should call the URL Path Validator ', function () {
       stubBankAccountDetails.throws(new ValidationError({ 'firstName': {} }))
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return request
+      request
         .post(`/first-time-claim/eligibility/${reference}/claim/${claimId}/bank-account-details`)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)

--- a/test/unit/routes/first-time/eligibility/claim/test-bus-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-bus-details.js
@@ -1,0 +1,86 @@
+const supertest = require('supertest')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const route = require('../../../../../../app/routes/first-time/eligibility/claim/bus-details')
+const app = routeHelper.build(route)
+
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+const expenseUrlRouter = require('../../../../../../app/services/routing/expenses-url-router')
+const insertExpense = require('../../../../../../app/services/data/insert-expense')
+
+describe('routes/first-time/eligibility/claim/bus-details', function () {
+  const VALID_ROUTE = `/first-time-claim/eligibility/${routeHelper.VALID_REFERENCE}/claim/${routeHelper.VALID_CLAIM_ID}/bus`
+  const VALID_BODY = {
+    'cost': '10',
+    'from': 'London',
+    'to': 'Hewell',
+    'return-journey': 'yes'
+  }
+
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe(`GET ${VALID_ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(200)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should call parseParams', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+        })
+    })
+  })
+
+  describe(`POST ${VALID_ROUTE}`, function () {
+    it('should respond with a 200 if expected body parameters are set', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
+      var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(VALID_BODY)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+          sinon.assert.calledOnce(stubInsertExpense)
+        })
+        .expect(302)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(400)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-bus-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-bus-details.js
@@ -30,14 +30,14 @@ describe('routes/first-time/eligibility/claim/bus-details', function () {
 
   describe(`GET ${VALID_ROUTE}`, function () {
     it('should respond with a 200', function () {
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(200)
     })
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -46,7 +46,7 @@ describe('routes/first-time/eligibility/claim/bus-details', function () {
 
     it('should call parseParams', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(expenseUrlRouterSpy)
@@ -58,7 +58,7 @@ describe('routes/first-time/eligibility/claim/bus-details', function () {
     it('should respond with a 200 if expected body parameters are set', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
       var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(VALID_BODY)
         .expect(function () {
@@ -70,7 +70,7 @@ describe('routes/first-time/eligibility/claim/bus-details', function () {
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -78,7 +78,7 @@ describe('routes/first-time/eligibility/claim/bus-details', function () {
     })
 
     it('should respond with a 400 if domain object validation fails.', function () {
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(400)
     })

--- a/test/unit/routes/first-time/eligibility/claim/test-car-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-car-details.js
@@ -1,0 +1,109 @@
+const supertest = require('supertest')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const route = require('../../../../../../app/routes/first-time/eligibility/claim/car-details')
+const app = routeHelper.build(route)
+
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+const expenseUrlRouter = require('../../../../../../app/services/routing/expenses-url-router')
+const getTravellingFromAndTo = require('../../../../../../app/services/data/get-travelling-from-and-to')
+const insertCarExpense = require('../../../../../../app/services/data/insert-car-expenses')
+
+describe('routes/first-time/eligibility/claim/car', function () {
+  const VALID_ROUTE = `/first-time-claim/eligibility/${routeHelper.VALID_REFERENCE}/claim/${routeHelper.VALID_CLAIM_ID}/car`
+  const VALID_BODY = {
+    'from': 'Belfast',
+    'to': 'Belfast City',
+    'toll': 'yes',
+    'toll-cost': '20',
+    'parking': 'yes',
+    'parking-cost': '20'
+  }
+  const INVALID_BODY = {
+    'toll': 'yes',
+    'toll-cost': '',
+    'parking': 'yes',
+    'parking-cost': ''
+  }
+
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe(`GET ${VALID_ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      sandbox.stub(getTravellingFromAndTo, 'get').resolves()
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(200)
+    })
+
+    it('should call the URL Path Validator', function () {
+      sandbox.stub(getTravellingFromAndTo, 'get').resolves()
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should call parseParams', function () {
+      sandbox.stub(getTravellingFromAndTo, 'get').resolves()
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+        })
+    })
+
+    it('should call parseParams', function () {
+      var getTravellingFromAndToSpy = sandbox.stub(getTravellingFromAndTo, 'get').resolves()
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(getTravellingFromAndToSpy)
+        })
+    })
+  })
+
+  describe(`POST ${VALID_ROUTE}`, function () {
+    it('should respond with a 200 if expected body parameters are set', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
+      var stubInsertCarExpense = sandbox.stub(insertCarExpense, 'insert').resolves()
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(VALID_BODY)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+          sinon.assert.calledOnce(stubInsertCarExpense)
+        })
+        .expect(302)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      sandbox.stub(insertCarExpense, 'insert').resolves()
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(INVALID_BODY)
+        .expect(400)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-car-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-car-details.js
@@ -40,7 +40,7 @@ describe('routes/first-time/eligibility/claim/car', function () {
   describe(`GET ${VALID_ROUTE}`, function () {
     it('should respond with a 200', function () {
       sandbox.stub(getTravellingFromAndTo, 'get').resolves()
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(200)
     })
@@ -48,7 +48,7 @@ describe('routes/first-time/eligibility/claim/car', function () {
     it('should call the URL Path Validator', function () {
       sandbox.stub(getTravellingFromAndTo, 'get').resolves()
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -58,7 +58,7 @@ describe('routes/first-time/eligibility/claim/car', function () {
     it('should call parseParams', function () {
       sandbox.stub(getTravellingFromAndTo, 'get').resolves()
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(expenseUrlRouterSpy)
@@ -67,7 +67,7 @@ describe('routes/first-time/eligibility/claim/car', function () {
 
     it('should call parseParams', function () {
       var getTravellingFromAndToSpy = sandbox.stub(getTravellingFromAndTo, 'get').resolves()
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(getTravellingFromAndToSpy)
@@ -79,7 +79,7 @@ describe('routes/first-time/eligibility/claim/car', function () {
     it('should respond with a 200 if expected body parameters are set', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
       var stubInsertCarExpense = sandbox.stub(insertCarExpense, 'insert').resolves()
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(VALID_BODY)
         .expect(function () {
@@ -92,7 +92,7 @@ describe('routes/first-time/eligibility/claim/car', function () {
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
       sandbox.stub(insertCarExpense, 'insert').resolves()
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -100,7 +100,7 @@ describe('routes/first-time/eligibility/claim/car', function () {
     })
 
     it('should respond with a 400 if domain object validation fails.', function () {
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(INVALID_BODY)
         .expect(400)

--- a/test/unit/routes/first-time/eligibility/claim/test-car-hire-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-car-hire-details.js
@@ -30,14 +30,14 @@ describe('routes/first-time/eligibility/claim/car-hire', function () {
 
   describe(`GET ${VALID_ROUTE}`, function () {
     it('should respond with a 200', function () {
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(200)
     })
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -46,7 +46,7 @@ describe('routes/first-time/eligibility/claim/car-hire', function () {
 
     it('should call parseParams', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(expenseUrlRouterSpy)
@@ -58,7 +58,7 @@ describe('routes/first-time/eligibility/claim/car-hire', function () {
     it('should respond with a 200 if expected body parameters are set', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
       var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(VALID_BODY)
         .expect(function () {
@@ -70,7 +70,7 @@ describe('routes/first-time/eligibility/claim/car-hire', function () {
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -78,7 +78,7 @@ describe('routes/first-time/eligibility/claim/car-hire', function () {
     })
 
     it('should respond with a 400 if domain object validation fails.', function () {
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(400)
     })

--- a/test/unit/routes/first-time/eligibility/claim/test-car-hire-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-car-hire-details.js
@@ -1,0 +1,86 @@
+const supertest = require('supertest')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const route = require('../../../../../../app/routes/first-time/eligibility/claim/car-hire-details')
+const app = routeHelper.build(route)
+
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+const expenseUrlRouter = require('../../../../../../app/services/routing/expenses-url-router')
+const insertExpense = require('../../../../../../app/services/data/insert-expense')
+
+describe('routes/first-time/eligibility/claim/car-hire', function () {
+  const VALID_ROUTE = `/first-time-claim/eligibility/${routeHelper.VALID_REFERENCE}/claim/${routeHelper.VALID_CLAIM_ID}/hire`
+  const VALID_BODY = {
+    'cost': '50',
+    'from': 'Belfast',
+    'to': 'Belfast City',
+    'duration': '1'
+  }
+
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe(`GET ${VALID_ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(200)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should call parseParams', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+        })
+    })
+  })
+
+  describe(`POST ${VALID_ROUTE}`, function () {
+    it('should respond with a 200 if expected body parameters are set', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
+      var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(VALID_BODY)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+          sinon.assert.calledOnce(stubInsertExpense)
+        })
+        .expect(302)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(400)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-claim-summary.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-claim-summary.js
@@ -54,7 +54,7 @@ describe('routes/first-time/eligibility/claim/claim-summary', function () {
 
     it('should call the URL Path Validator ', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return request
+      request
         .get(`/first-time-claim/eligibility/${reference}/claim/${claimId}/summary`)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -76,7 +76,7 @@ describe('routes/first-time/eligibility/claim/claim-summary', function () {
 
     it('should call the URL Path Validator ', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return request
+      request
         .post(`/first-time-claim/eligibility/${reference}/claim/${claimId}/summary`)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -99,7 +99,7 @@ describe('routes/first-time/eligibility/claim/claim-summary', function () {
 
     it('should call the URL Path Validator ', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return request
+      request
         .post(`/first-time-claim/eligibility/${reference}/claim/${claimId}/summary/remove/${claimExpenseId}`)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)

--- a/test/unit/routes/first-time/eligibility/claim/test-expenses.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-expenses.js
@@ -1,0 +1,71 @@
+const supertest = require('supertest')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const route = require('../../../../../../app/routes/first-time/eligibility/claim/expenses')
+const app = routeHelper.build(route)
+
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+const expenseUrlRouter = require('../../../../../../app/services/routing/expenses-url-router')
+
+describe('routes/first-time/eligibility/claim/expenses', function () {
+  const VALID_ROUTE = `/first-time-claim/eligibility/${routeHelper.VALID_REFERENCE}/claim/${routeHelper.VALID_CLAIM_ID}`
+  const VALID_BODY = {
+    'expenses': 'some expenses'
+  }
+
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe(`GET ${VALID_ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(200)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+  })
+
+  describe(`POST ${VALID_ROUTE}`, function () {
+    it('should respond with a 200 if expected body parameters are set', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(VALID_BODY)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+        })
+        .expect(302)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should respond with a 400 if validation fails.', function () {
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(400)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-expenses.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-expenses.js
@@ -26,14 +26,14 @@ describe('routes/first-time/eligibility/claim/expenses', function () {
 
   describe(`GET ${VALID_ROUTE}`, function () {
     it('should respond with a 200', function () {
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(200)
     })
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -44,7 +44,7 @@ describe('routes/first-time/eligibility/claim/expenses', function () {
   describe(`POST ${VALID_ROUTE}`, function () {
     it('should respond with a 200 if expected body parameters are set', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(VALID_BODY)
         .expect(function () {
@@ -55,7 +55,7 @@ describe('routes/first-time/eligibility/claim/expenses', function () {
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -63,7 +63,7 @@ describe('routes/first-time/eligibility/claim/expenses', function () {
     })
 
     it('should respond with a 400 if validation fails.', function () {
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(400)
     })

--- a/test/unit/routes/first-time/eligibility/claim/test-ferry-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-ferry-details.js
@@ -31,14 +31,14 @@ describe('routes/first-time/eligibility/claim/ferry', function () {
 
   describe(`GET ${VALID_ROUTE}`, function () {
     it('should respond with a 200', function () {
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(200)
     })
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -47,7 +47,7 @@ describe('routes/first-time/eligibility/claim/ferry', function () {
 
     it('should call parseParams', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(expenseUrlRouterSpy)
@@ -59,7 +59,7 @@ describe('routes/first-time/eligibility/claim/ferry', function () {
     it('should respond with a 200 if expected body parameters are set', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
       var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(VALID_BODY)
         .expect(function () {
@@ -71,7 +71,7 @@ describe('routes/first-time/eligibility/claim/ferry', function () {
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -79,7 +79,7 @@ describe('routes/first-time/eligibility/claim/ferry', function () {
     })
 
     it('should respond with a 400 if domain object validation fails.', function () {
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(400)
     })

--- a/test/unit/routes/first-time/eligibility/claim/test-ferry-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-ferry-details.js
@@ -1,0 +1,87 @@
+const supertest = require('supertest')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const route = require('../../../../../../app/routes/first-time/eligibility/claim/ferry-details')
+const app = routeHelper.build(route)
+
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+const expenseUrlRouter = require('../../../../../../app/services/routing/expenses-url-router')
+const insertExpense = require('../../../../../../app/services/data/insert-expense')
+
+describe('routes/first-time/eligibility/claim/ferry', function () {
+  const VALID_ROUTE = `/first-time-claim/eligibility/${routeHelper.VALID_REFERENCE}/claim/${routeHelper.VALID_CLAIM_ID}/ferry`
+  const VALID_BODY = {
+    'cost': '10',
+    'from': 'portsmouth',
+    'to': 'the isle of wight',
+    'return-journey': 'yes',
+    'ticket-type': 'car passenger'
+  }
+
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe(`GET ${VALID_ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(200)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should call parseParams', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+        })
+    })
+  })
+
+  describe(`POST ${VALID_ROUTE}`, function () {
+    it('should respond with a 200 if expected body parameters are set', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
+      var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(VALID_BODY)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+          sinon.assert.calledOnce(stubInsertExpense)
+        })
+        .expect(302)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(400)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-light-refreshment-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-light-refreshment-details.js
@@ -28,14 +28,14 @@ describe('routes/first-time/eligibility/claim/light-refreshment', function () {
 
   describe(`GET ${VALID_ROUTE}`, function () {
     it('should respond with a 200', function () {
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(200)
     })
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -44,7 +44,7 @@ describe('routes/first-time/eligibility/claim/light-refreshment', function () {
 
     it('should call parseParams', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(expenseUrlRouterSpy)
@@ -56,7 +56,7 @@ describe('routes/first-time/eligibility/claim/light-refreshment', function () {
     it('should respond with a 200 if expected body parameters are set', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
       var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(VALID_BODY)
         .expect(function () {
@@ -68,7 +68,7 @@ describe('routes/first-time/eligibility/claim/light-refreshment', function () {
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -76,7 +76,7 @@ describe('routes/first-time/eligibility/claim/light-refreshment', function () {
     })
 
     it('should respond with a 400 if domain object validation fails.', function () {
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(400)
     })

--- a/test/unit/routes/first-time/eligibility/claim/test-light-refreshment-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-light-refreshment-details.js
@@ -1,0 +1,84 @@
+const supertest = require('supertest')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const route = require('../../../../../../app/routes/first-time/eligibility/claim/light-refreshment-details')
+const app = routeHelper.build(route)
+
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+const expenseUrlRouter = require('../../../../../../app/services/routing/expenses-url-router')
+const insertExpense = require('../../../../../../app/services/data/insert-expense')
+
+describe('routes/first-time/eligibility/claim/light-refreshment', function () {
+  const VALID_ROUTE = `/first-time-claim/eligibility/${routeHelper.VALID_REFERENCE}/claim/${routeHelper.VALID_CLAIM_ID}/refreshment`
+  const VALID_BODY = {
+    'cost': '10',
+    'travel-time': '1'
+  }
+
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe(`GET ${VALID_ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(200)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should call parseParams', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+        })
+    })
+  })
+
+  describe(`POST ${VALID_ROUTE}`, function () {
+    it('should respond with a 200 if expected body parameters are set', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
+      var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(VALID_BODY)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+          sinon.assert.calledOnce(stubInsertExpense)
+        })
+        .expect(302)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(400)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-plane-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-plane-details.js
@@ -1,0 +1,86 @@
+const supertest = require('supertest')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const route = require('../../../../../../app/routes/first-time/eligibility/claim/plane-details')
+const app = routeHelper.build(route)
+
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+const expenseUrlRouter = require('../../../../../../app/services/routing/expenses-url-router')
+const insertExpense = require('../../../../../../app/services/data/insert-expense')
+
+describe('routes/first-time/eligibility/claim/plane', function () {
+  const VALID_ROUTE = `/first-time-claim/eligibility/${routeHelper.VALID_REFERENCE}/claim/${routeHelper.VALID_CLAIM_ID}/plane`
+  const VALID_BODY = {
+    'cost': '100',
+    'from': 'Heathrow',
+    'to': 'Belfast City',
+    'return-journey': 'yes'
+  }
+
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe(`GET ${VALID_ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(200)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should call parseParams', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+        })
+    })
+  })
+
+  describe(`POST ${VALID_ROUTE}`, function () {
+    it('should respond with a 200 if expected body parameters are set', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
+      var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(VALID_BODY)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+          sinon.assert.calledOnce(stubInsertExpense)
+        })
+        .expect(302)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(400)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-plane-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-plane-details.js
@@ -30,14 +30,14 @@ describe('routes/first-time/eligibility/claim/plane', function () {
 
   describe(`GET ${VALID_ROUTE}`, function () {
     it('should respond with a 200', function () {
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(200)
     })
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -46,7 +46,7 @@ describe('routes/first-time/eligibility/claim/plane', function () {
 
     it('should call parseParams', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(expenseUrlRouterSpy)
@@ -58,7 +58,7 @@ describe('routes/first-time/eligibility/claim/plane', function () {
     it('should respond with a 200 if expected body parameters are set', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
       var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(VALID_BODY)
         .expect(function () {
@@ -70,7 +70,7 @@ describe('routes/first-time/eligibility/claim/plane', function () {
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -78,7 +78,7 @@ describe('routes/first-time/eligibility/claim/plane', function () {
     })
 
     it('should respond with a 400 if domain object validation fails.', function () {
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(400)
     })

--- a/test/unit/routes/first-time/eligibility/claim/test-taxi-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-taxi-details.js
@@ -1,0 +1,85 @@
+const supertest = require('supertest')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const route = require('../../../../../../app/routes/first-time/eligibility/claim/taxi-details')
+const app = routeHelper.build(route)
+
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+const expenseUrlRouter = require('../../../../../../app/services/routing/expenses-url-router')
+const insertExpense = require('../../../../../../app/services/data/insert-expense')
+
+describe('routes/first-time/eligibility/claim/taxi', function () {
+  const VALID_ROUTE = `/first-time-claim/eligibility/${routeHelper.VALID_REFERENCE}/claim/${routeHelper.VALID_CLAIM_ID}/taxi`
+  const VALID_BODY = {
+    'cost': '100',
+    'from': 'Belfast',
+    'to': 'Belfast City'
+  }
+
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe(`GET ${VALID_ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(200)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should call parseParams', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+        })
+    })
+  })
+
+  describe(`POST ${VALID_ROUTE}`, function () {
+    it('should respond with a 200 if expected body parameters are set', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
+      var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(VALID_BODY)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+          sinon.assert.calledOnce(stubInsertExpense)
+        })
+        .expect(302)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(400)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-taxi-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-taxi-details.js
@@ -29,14 +29,14 @@ describe('routes/first-time/eligibility/claim/taxi', function () {
 
   describe(`GET ${VALID_ROUTE}`, function () {
     it('should respond with a 200', function () {
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(200)
     })
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -45,7 +45,7 @@ describe('routes/first-time/eligibility/claim/taxi', function () {
 
     it('should call parseParams', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(expenseUrlRouterSpy)
@@ -57,7 +57,7 @@ describe('routes/first-time/eligibility/claim/taxi', function () {
     it('should respond with a 200 if expected body parameters are set', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
       var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(VALID_BODY)
         .expect(function () {
@@ -69,7 +69,7 @@ describe('routes/first-time/eligibility/claim/taxi', function () {
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -77,7 +77,7 @@ describe('routes/first-time/eligibility/claim/taxi', function () {
     })
 
     it('should respond with a 400 if domain object validation fails.', function () {
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(400)
     })

--- a/test/unit/routes/first-time/eligibility/claim/test-train-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-train-details.js
@@ -30,14 +30,14 @@ describe('routes/first-time/eligibility/claim/train', function () {
 
   describe(`GET ${VALID_ROUTE}`, function () {
     it('should respond with a 200', function () {
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(200)
     })
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -46,7 +46,7 @@ describe('routes/first-time/eligibility/claim/train', function () {
 
     it('should call parseParams', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
-      return supertest(app)
+      supertest(app)
         .get(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(expenseUrlRouterSpy)
@@ -58,7 +58,7 @@ describe('routes/first-time/eligibility/claim/train', function () {
     it('should respond with a 200 if expected body parameters are set', function () {
       var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
       var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .send(VALID_BODY)
         .expect(function () {
@@ -70,7 +70,7 @@ describe('routes/first-time/eligibility/claim/train', function () {
 
     it('should call the URL Path Validator', function () {
       var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(function () {
           sinon.assert.calledOnce(urlPathValidatorSpy)
@@ -78,7 +78,7 @@ describe('routes/first-time/eligibility/claim/train', function () {
     })
 
     it('should respond with a 400 if domain object validation fails.', function () {
-      return supertest(app)
+      supertest(app)
         .post(VALID_ROUTE)
         .expect(400)
     })

--- a/test/unit/routes/first-time/eligibility/claim/test-train-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-train-details.js
@@ -1,0 +1,86 @@
+const supertest = require('supertest')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const route = require('../../../../../../app/routes/first-time/eligibility/claim/train-details')
+const app = routeHelper.build(route)
+
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+const expenseUrlRouter = require('../../../../../../app/services/routing/expenses-url-router')
+const insertExpense = require('../../../../../../app/services/data/insert-expense')
+
+describe('routes/first-time/eligibility/claim/train', function () {
+  const VALID_ROUTE = `/first-time-claim/eligibility/${routeHelper.VALID_REFERENCE}/claim/${routeHelper.VALID_CLAIM_ID}/train`
+  const VALID_BODY = {
+    'cost': '100',
+    'from': 'Belfast',
+    'to': 'Belfast City',
+    'return-journey': 'yes'
+  }
+
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe(`GET ${VALID_ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(200)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should call parseParams', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'parseParams')
+      return supertest(app)
+        .get(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+        })
+    })
+  })
+
+  describe(`POST ${VALID_ROUTE}`, function () {
+    it('should respond with a 200 if expected body parameters are set', function () {
+      var expenseUrlRouterSpy = sandbox.spy(expenseUrlRouter, 'getRedirectUrl')
+      var stubInsertExpense = sandbox.stub(insertExpense, 'insert').resolves()
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .send(VALID_BODY)
+        .expect(function () {
+          sinon.assert.calledOnce(expenseUrlRouterSpy)
+          sinon.assert.calledOnce(stubInsertExpense)
+        })
+        .expect(302)
+    })
+
+    it('should call the URL Path Validator', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
+        })
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      return supertest(app)
+        .post(VALID_ROUTE)
+        .expect(400)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/new-claim/test-future-or-past-visit.js
+++ b/test/unit/routes/first-time/eligibility/new-claim/test-future-or-past-visit.js
@@ -4,21 +4,25 @@ const expect = require('chai').expect
 const express = require('express')
 const bodyParser = require('body-parser')
 const mockViewEngine = require('../../../mock-view-engine')
+const sinon = require('sinon')
+const UrlPathValidator = require('../../../../../../app/services/validators/url-path-validator')
+
 var request
 
 describe('routes/first-time/eligibility/new-claim/future-or-past-visit', function () {
-  var urlValidatorCalled = false
-
+  var sandbox
   beforeEach(function () {
+    sandbox = sinon.sandbox.create()
     var app = express()
     app.use(bodyParser.urlencoded({ extended: false }))
     mockViewEngine(app, '../../../app/views')
-    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/new-claim/future-or-past-visit', {
-      '../../../../services/validators/url-path-validator': function () { urlValidatorCalled = true }
-    })
+    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/new-claim/future-or-past-visit', {})
     route(app)
     request = supertest(app)
-    urlValidatorCalled = false
+  })
+
+  afterEach(function () {
+    sandbox.restore()
   })
 
   describe('GET /first-time/eligibility/:reference/new-claim', function () {
@@ -26,10 +30,18 @@ describe('routes/first-time/eligibility/new-claim/future-or-past-visit', functio
       request
         .get('/first-time-claim/eligibility/1234567/new-claim')
         .expect(200)
-        .end(function (error, response) {
+        .end(function (error) {
           expect(error).to.be.null
-          expect(urlValidatorCalled).to.be.true
           done()
+        })
+    })
+
+    it('should call the URL Path Validator ', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return request
+        .get('/first-time-claim/eligibility/1234567/new-claim')
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
         })
     })
   })
@@ -46,6 +58,16 @@ describe('routes/first-time/eligibility/new-claim/future-or-past-visit', functio
           expect(error).to.be.null
           expect(response.header.location).to.equal(`/first-time-claim/eligibility/${reference}/new-claim/past`)
           done()
+        })
+    })
+
+    it('should call the URL Path Validator ', function () {
+      var reference = '1234567'
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return request
+        .post(`/first-time-claim/eligibility/${reference}/new-claim`)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
         })
     })
   })

--- a/test/unit/routes/first-time/test-about-the-prisoner.js
+++ b/test/unit/routes/first-time/test-about-the-prisoner.js
@@ -7,18 +7,19 @@ const express = require('express')
 const bodyParser = require('body-parser')
 const mockViewEngine = require('../mock-view-engine')
 const firstTimeClaim = require('../../../../app/services/data/first-time-claim')
+const UrlPathValidator = require('../../../../app/services/validators/url-path-validator')
+
 var stubAboutThePrisonerValidator
 var request
 
 describe('routes/first-time/about-the-prisoner', function () {
-  var urlValidatorCalled = false
-
+  var sandbox
   beforeEach(function () {
+    sandbox = sinon.sandbox.create()
     stubAboutThePrisonerValidator = sinon.stub()
     var route = proxyquire('../../../../app/routes/first-time/about-the-prisoner', {
       '../../services/data/first-time-claim': firstTimeClaim,
-      '../../services/validators/first-time/about-the-prisoner-validator': stubAboutThePrisonerValidator,
-      '../../services/validators/url-path-validator': function () { urlValidatorCalled = true }
+      '../../services/validators/first-time/about-the-prisoner-validator': stubAboutThePrisonerValidator
     })
 
     var app = express()
@@ -26,24 +27,34 @@ describe('routes/first-time/about-the-prisoner', function () {
     mockViewEngine(app, '../../../app/views')
     route(app)
     request = supertest(app)
-    urlValidatorCalled = false
+  })
+
+  afterEach(function () {
+    sandbox.restore()
   })
 
   describe('GET /first-time/:dob/:relationship/:benefit', function () {
-    it('should respond with a 200 for valid path parameters', function (done) {
+    it('should respond with a 200 for valid path parameters', function () {
       request
         .get('/first-time/1980-01-01/partner/income-support')
         .expect(200)
         .end(function (error) {
           expect(error).to.be.null
-          expect(urlValidatorCalled).to.be.true
-          done()
+        })
+    })
+
+    it('should call the URL Path Validator ', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return request
+        .get('/first-time/1980-01-01/partner/income-support')
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
         })
     })
   })
 
   describe('POST /first-time/:dob/:relationship/:benefit', function () {
-    it('should persist data and redirect to first-time/about-you for valid data', function (done) {
+    it('should persist data and redirect to first-time/about-you for valid data', function () {
       var newReference = '1234567'
       var stubInsertNewEligibilityAndPrisoner = sinon.stub(firstTimeClaim, 'insertNewEligibilityAndPrisoner').resolves(newReference)
       stubAboutThePrisonerValidator.returns(false)
@@ -53,22 +64,28 @@ describe('routes/first-time/about-the-prisoner', function () {
         .expect(302)
         .end(function (error, response) {
           expect(error).to.be.null
-          expect(urlValidatorCalled).to.be.true
           expect(stubAboutThePrisonerValidator.calledOnce).to.be.true
           expect(stubInsertNewEligibilityAndPrisoner.calledOnce).to.be.true
           expect(response.header.location).to.equal(`/first-time/1980-01-01/partner/income-support/${newReference}`)
-          done()
         })
     })
-    it('should respond with a 400 for invalid data', function (done) {
+    it('should respond with a 400 for invalid data', function () {
       stubAboutThePrisonerValidator.returns({ 'firstName': [] })
       request
         .post('/first-time/1980-01-01/partner/income-support')
         .expect(400)
-        .end(function (error, response) {
+        .end(function (error) {
           expect(error).to.be.null
           expect(stubAboutThePrisonerValidator.calledOnce).to.be.true
-          done()
+        })
+    })
+
+    it('should call the URL Path Validator ', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return request
+        .post('/first-time/1980-01-01/partner/income-support')
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
         })
     })
   })

--- a/test/unit/routes/first-time/test-about-you.js
+++ b/test/unit/routes/first-time/test-about-you.js
@@ -6,21 +6,21 @@ require('sinon-bluebird')
 const express = require('express')
 const bodyParser = require('body-parser')
 const mockViewEngine = require('../mock-view-engine')
+const UrlPathValidator = require('../../../../app/services/validators/url-path-validator')
 
 var stubInsertVisitor
 var stubAboutYouValidator
 var request
 
 describe('routes/first-time/about-you', function () {
-  var urlValidatorCalled = false
-
+  var sandbox
   beforeEach(function () {
+    sandbox = sinon.sandbox.create()
     stubInsertVisitor = sinon.stub()
     stubAboutYouValidator = sinon.stub()
     var route = proxyquire('../../../../app/routes/first-time/about-you', {
       '../../services/data/insert-visitor': stubInsertVisitor,
-      '../../services/validators/first-time/about-you-validator': stubAboutYouValidator,
-      '../../services/validators/url-path-validator': function () { urlValidatorCalled = true }
+      '../../services/validators/first-time/about-you-validator': stubAboutYouValidator
     })
 
     var app = express()
@@ -28,7 +28,10 @@ describe('routes/first-time/about-you', function () {
     mockViewEngine(app, '../../../app/views')
     route(app)
     request = supertest(app)
-    urlValidatorCalled = false
+  })
+
+  afterEach(function () {
+    sandbox.restore()
   })
 
   describe('GET /first-time/:dob/:relationship/:benefit/:reference', function () {
@@ -36,43 +39,59 @@ describe('routes/first-time/about-you', function () {
       request
         .get('/first-time/1980-01-01/partner/income-support/1234567')
         .expect(200)
-        .end(function (error, response) {
+        .end(function (error) {
           expect(error).to.be.null
-          expect(urlValidatorCalled).to.be.true
           done()
+        })
+    })
+
+    it('should call the URL Path Validator ', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return request
+        .get('/first-time/1980-01-01/partner/income-support/1234567')
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
         })
     })
   })
 
   describe('POST /first-time/:dob/:relationship/:benefit/:reference', function () {
-    it('should persist data and redirect to /application-submitted/:reference for valid data', function (done) {
+    it('should persist data and redirect to /application-submitted/:reference for valid data', function () {
       var reference = '1234567'
       stubInsertVisitor.resolves()
       stubAboutYouValidator.returns(false)
 
-      request
+      return request
         .post(`/first-time/1980-01-01/partner/income-support/${reference}`)
         .expect(302)
         .end(function (error, response) {
           expect(error).to.be.null
-          expect(urlValidatorCalled).to.be.true
           expect(stubAboutYouValidator.calledOnce).to.be.true
           expect(stubInsertVisitor.calledOnce).to.be.true
           expect(response.header.location).to.equal(`/first-time-claim/eligibility/${reference}/new-claim`)
-          done()
         })
     })
+
     it('should respond with a 400 for invalid data', function (done) {
       var reference = '1234567'
       stubAboutYouValidator.returns({ 'Title': [] })
       request
         .post(`/first-time/1980-01-01/partner/income-support/${reference}`)
         .expect(400)
-        .end(function (error, response) {
+        .end(function (error) {
           expect(error).to.be.null
-          expect(stubAboutYouValidator.calledOnce).to.be.true
-          expect(urlValidatorCalled).to.be.true
           done()
+        })
+    })
+
+    it('should call the URL Path Validator ', function () {
+      var reference = '1234567'
+      stubAboutYouValidator.returns({ 'Title': [] })
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return request
+        .post(`/first-time/1980-01-01/partner/income-support/${reference}`)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
         })
     })
   })

--- a/test/unit/routes/first-time/test-benefits.js
+++ b/test/unit/routes/first-time/test-benefits.js
@@ -3,15 +3,17 @@ const proxyquire = require('proxyquire')
 const express = require('express')
 const mockViewEngine = require('../mock-view-engine')
 const bodyParser = require('body-parser')
-const expect = require('chai').expect
+const sinon = require('sinon')
+const UrlPathValidator = require('../../../../app/services/validators/url-path-validator')
 
 var validationErrors
 
 describe('routes/first-time/benefits', function () {
   var request
-  var urlValidatorCalled = false
+  var sandbox
 
   beforeEach(function () {
+    sandbox = sinon.sandbox.create()
     var app = express()
     app.use(bodyParser.json())
     mockViewEngine(app, '../../../app/views')
@@ -21,73 +23,71 @@ describe('routes/first-time/benefits', function () {
 
     var route = proxyquire(
       '../../../../app/routes/first-time/benefits', {
-        '../../services/validators/eligibility/benefit-validator': function () { return validationErrors },
-        '../../services/validators/url-path-validator': function () { urlValidatorCalled = true }
+        '../../services/validators/eligibility/benefit-validator': function () { return validationErrors }
       })
     route(app)
-    urlValidatorCalled = false
   })
 
-  // benefits
+  afterEach(function () {
+    sandbox.restore()
+  })
+
   describe('GET /first-time/:dob/:relationship', function () {
-    it('should respond with a 200', function (done) {
-      request
+    it('should respond with a 200', function () {
+      return request
         .get('/first-time/1980-01-01/partner')
         .expect(200)
+    })
+
+    it('should call the URL Path Validator ', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return request
+        .get('/first-time/1980-01-01/partner')
         .expect(function () {
-          expect(urlValidatorCalled).to.be.true
+          sinon.assert.calledOnce(urlPathValidatorSpy)
         })
-        .end(done)
     })
   })
 
   describe('POST /first-time/:dob/:relationship', function () {
-    it('should respond with a 302', function (done) {
-      request
+    it('should respond with a 302', function () {
+      return request
         .post('/first-time/1980-01-01/partner')
         .expect(302)
-        .end(function () {
-          expect(urlValidatorCalled).to.be.true
-          done()
-        })
     })
 
-    it('should response with a 400 if validation fails', function (done) {
+    it('should response with a 400 if validation fails', function () {
       validationErrors = { 'benefit': [] }
-      request
+      return request
         .post('/first-time/1980-01-01/partner')
         .expect(400)
-        .end(function () {
-          expect(urlValidatorCalled).to.be.true
-          done()
-        })
     })
 
-    it('should redirect to eligibility-fail page if benefit is none', function (done) {
-      request
+    it('should redirect to eligibility-fail page if benefit is none', function () {
+      return request
         .post('/first-time/1980-01-01/partner')
         .send({
           benefit: 'none'
         })
         .expect('location', '/eligibility-fail')
-        .end(function () {
-          expect(urlValidatorCalled).to.be.true
-          done()
-        })
     })
 
-    it('should redirect to /first-time/:dob/:relationship/:benefit page if benefit is any value other than none', function (done) {
+    it('should redirect to /first-time/:dob/:relationship/:benefit page if benefit is any value other than none', function () {
       var benefit = 'no'
-
       request
         .post('/first-time/1980-01-01/partner')
         .send({
           benefit: benefit
         })
         .expect('location', `/first-time/1980-01-01/partner/${benefit}`)
-        .end(function () {
-          expect(urlValidatorCalled).to.be.true
-          done()
+    })
+
+    it('should call the URL Path Validator ', function () {
+      var urlPathValidatorSpy = sandbox.spy(UrlPathValidator, 'validate')
+      return request
+        .post('/first-time/1980-01-01/partner')
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorSpy)
         })
     })
   })

--- a/test/unit/services/routing/test-expenses-url-router.js
+++ b/test/unit/services/routing/test-expenses-url-router.js
@@ -4,18 +4,20 @@ const expensesUrlRouter = require('../../../../app/services/routing/expenses-url
 const paramBuilder = require('../../../../app/services/routing/param-builder')
 
 describe('services/routing/expenses-url-router', function () {
-  describe('parseParams', function () {
-    var buildFormatted = sinon.stub(paramBuilder, 'buildFormatted')
+  var sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+  })
 
-    it('should call buildFormatted to build and format the params parameter', function (done) {
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('parseParams', function () {
+    it('should call buildFormatted to build and format the params parameter', function () {
+      var buildFormatted = sandbox.stub(paramBuilder, 'buildFormatted')
       expensesUrlRouter.parseParams([])
       sinon.assert.calledOnce(buildFormatted)
-      done()
-    })
-
-    after(function (done) {
-      buildFormatted.restore()
-      done()
     })
   })
 
@@ -41,83 +43,74 @@ describe('services/routing/expenses-url-router', function () {
     }
     const VALID_REQUEST_OUTPUT = `/first-time-claim/eligibility/${REFERENCE}/claim/${CLAIM_ID}/${VALID_PARAM_ONE}?${VALID_PARAM_TWO}=`
 
-    it('should throw an error if req is invalid', function (done) {
-      expect(function () {
+    it('should throw an error if req is invalid', function () {
+      return expect(function () {
         expensesUrlRouter.getRedirectUrl(
           null)
       }).to.throw(Error)
-      done()
     })
 
-    it('should throw an error if req.body is invalid', function (done) {
-      expect(function () {
+    it('should throw an error if req.body is invalid', function () {
+      return expect(function () {
         expensesUrlRouter.getRedirectUrl({
           body: null
         })
       }).to.throw(Error)
-      done()
     })
 
-    it('should throw an error if req.params is invalid', function (done) {
-      expect(function () {
+    it('should throw an error if req.params is invalid', function () {
+      return expect(function () {
         expensesUrlRouter.getRedirectUrl({
           params: null
         })
       }).to.throw(Error)
-      done()
     })
 
-    it('should throw an error if req.params.reference is invalid', function (done) {
-      expect(function () {
+    it('should throw an error if req.params.reference is invalid', function () {
+      return expect(function () {
         expensesUrlRouter.getRedirectUrl({
           params: {
             reference: null
           }
         })
       }).to.throw(Error)
-      done()
     })
 
-    it('should throw an error if req.params.claimId is invalid', function (done) {
-      expect(function () {
+    it('should throw an error if req.params.claimId is invalid', function () {
+      return expect(function () {
         expensesUrlRouter.getRedirectUrl({
           params: {
             claimId: null
           }
         })
       }).to.throw(Error)
-      done()
     })
 
-    it('should throw an error if req.originalUrl is invalid', function (done) {
-      expect(function () {
+    it('should throw an error if req.originalUrl is invalid', function () {
+      return expect(function () {
         expensesUrlRouter.getRedirectUrl({
           originalUrl: null
         })
       }).to.throw(Error)
-      done()
     })
 
-    it('should throw an error if req.query is invalid', function (done) {
-      expect(function () {
+    it('should throw an error if req.query is invalid', function () {
+      return expect(function () {
         expensesUrlRouter.getRedirectUrl({
           query: null
         })
       }).to.throw(Error)
-      done()
     })
 
-    it('should return a url path if passed a valid request and add-another-journey was not set', function (done) {
+    it('should return a url path if passed a valid request and add-another-journey was not set', function () {
       var result = expensesUrlRouter.getRedirectUrl(validRequest)
-      expect(result).to.be.equal(VALID_REQUEST_OUTPUT)
-      done()
+      return expect(result).to.be.equal(VALID_REQUEST_OUTPUT)
     })
 
-    it('should return the originalUrl if passed a valid request with add-another-journey set', function (done) {
+    it('should return the originalUrl if passed a valid request with add-another-journey set', function () {
       validRequest.body['add-another-journey'] = 'on'
       var result = expensesUrlRouter.getRedirectUrl(validRequest)
-      expect(result).to.be.equal(ORIGINAL_URL)
-      done()
+      return expect(result).to.be.equal(ORIGINAL_URL)
     })
   })
 })

--- a/test/unit/services/validators/test-url-path-validator.js
+++ b/test/unit/services/validators/test-url-path-validator.js
@@ -17,88 +17,75 @@ describe('services/validators/url-path-validator', function () {
   const VALID_CLAIMID = { claimId: '123' }
   const INVALID_CLAIMID = { claimId: 'invalid' }
 
-  it('should throw error if passed null', function (done) {
-    expect(function () {
-      UrlPathValidator(null)
+  it('should throw error if passed null', function () {
+    return expect(function () {
+      UrlPathValidator.validate(null)
     }).to.throw(TypeError)
-    done()
   })
 
-  it('should throw error if passed undefined', function (done) {
-    expect(function () {
-      UrlPathValidator(undefined)
+  it('should throw error if passed undefined', function () {
+    return expect(function () {
+      UrlPathValidator.validate(undefined)
     }).to.throw(TypeError)
-    done()
   })
 
-  it('should throw Error if passed an invalid dob value', function (done) {
-    expect(function () {
-      UrlPathValidator(INVALID_DOB)
+  it('should throw Error if passed an invalid dob value', function () {
+    return expect(function () {
+      UrlPathValidator.validate(INVALID_DOB)
     }).to.throw(Error)
-    done()
   })
 
-  it('should throw Error if passed an invalid relationship value', function (done) {
-    expect(function () {
-      UrlPathValidator(INVALID_RELATIONSHIP)
+  it('should throw Error if passed an invalid relationship value', function () {
+    return expect(function () {
+      UrlPathValidator.validate(INVALID_RELATIONSHIP)
     }).to.throw(Error)
-    done()
   })
 
-  it('should throw Error if passed an invalid benefit value', function (done) {
-    expect(function () {
-      UrlPathValidator(INVALID_BENEFIT)
+  it('should throw Error if passed an invalid benefit value', function () {
+    return expect(function () {
+      UrlPathValidator.validate(INVALID_BENEFIT)
     }).to.throw(Error)
-    done()
   })
 
-  it('should throw Error if passed an invalid reference value', function (done) {
-    expect(function () {
-      UrlPathValidator(INVALID_REFERENCE)
+  it('should throw Error if passed an invalid reference value', function () {
+    return expect(function () {
+      UrlPathValidator.validate(INVALID_REFERENCE)
     }).to.throw(Error)
-    done()
   })
 
-  it('should throw Error if passed an invalid claimId value', function (done) {
-    expect(function () {
-      UrlPathValidator(INVALID_CLAIMID)
+  it('should throw Error if passed an invalid claimId value', function () {
+    return expect(function () {
+      UrlPathValidator.validate(INVALID_CLAIMID)
     }).to.throw(Error)
-    done()
   })
 
-  it('should return undefined if passed a valid dob value', function (done) {
-    var result = UrlPathValidator(VALID_DOB)
-    expect(result).to.equal(undefined)
-    done()
+  it('should return undefined if passed a valid dob value', function () {
+    var result = UrlPathValidator.validate(VALID_DOB)
+    return expect(result).to.equal(undefined)
   })
 
-  it('should return undefined if passed a valid relationship value', function (done) {
-    var result = UrlPathValidator(VALID_RELATIONSHIP)
-    expect(result).to.equal(undefined)
-    done()
+  it('should return undefined if passed a valid relationship value', function () {
+    var result = UrlPathValidator.validate(VALID_RELATIONSHIP)
+    return expect(result).to.equal(undefined)
   })
 
-  it('should return undefined if passed a valid dob value', function (done) {
-    var result = UrlPathValidator(VALID_DOB)
-    expect(result).to.equal(undefined)
-    done()
+  it('should return undefined if passed a valid dob value', function () {
+    var result = UrlPathValidator.validate(VALID_DOB)
+    return expect(result).to.equal(undefined)
   })
 
-  it('should return undefined if passed a valid benefit value', function (done) {
-    var result = UrlPathValidator(VALID_BENEFIT)
-    expect(result).to.equal(undefined)
-    done()
+  it('should return undefined if passed a valid benefit value', function () {
+    var result = UrlPathValidator.validate(VALID_BENEFIT)
+    return expect(result).to.equal(undefined)
   })
 
-  it('should return undefined if passed a valid reference value', function (done) {
-    var result = UrlPathValidator(VALID_REFERENCE)
-    expect(result).to.equal(undefined)
-    done()
+  it('should return undefined if passed a valid reference value', function () {
+    var result = UrlPathValidator.validate(VALID_REFERENCE)
+    return expect(result).to.equal(undefined)
   })
 
-  it('should return undefined if passed a valid claimId value', function (done) {
-    var result = UrlPathValidator(VALID_CLAIMID)
-    expect(result).to.equal(undefined)
-    done()
+  it('should return undefined if passed a valid claimId value', function () {
+    var result = UrlPathValidator.validate(VALID_CLAIMID)
+    return expect(result).to.equal(undefined)
   })
 })


### PR DESCRIPTION
- Added a route-helper that encapsulates the boiler plate route test setup.
- Added unit tests for the expense routes. Each using the new route helper.
- Added afterEach global to package.json.
- url-path-validator.js is now called via a method (validate) this is to allow spying with sinon. 
- insert-expense.js is now called via a method (insert) this is to allow spying with sinon. 
- insert-car-expenses.js is now called via a method (insert) this is to allow spying with sinon.
- Updated all functions using the files to handle the altered interface.
- Updated existing unit tests to handle the altered interface.
- Removed done calls from all edited tests, where possible.

## Checklist

- [x] Unit tests
- [x] End-to-End tests
- [x] Code coverage checked
- [x] Coding standards
- [x] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated