### PR TITLE
Added route tests for each of the expense pages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
       "describe",
       "before",
       "beforeEach",
+      "afterEach",
       "after",
       "it",
       "browser"

--- a/test/helpers/routes/route-helper.js
+++ b/test/helpers/routes/route-helper.js
@@ -1,0 +1,22 @@
+const mockViewEngine = require('../../unit/routes/mock-view-engine')
+const express = require('express')
+const bodyParser = require('body-parser')
+
+const VIEWS_DIRECTORY = '../../../app/views'
+
+module.exports.buildApp = function (route) {
+  var app = express()
+  app.use(bodyParser.urlencoded({
+    extended: false
+  }))
+
+  route(app)
+  mockViewEngine(app, VIEWS_DIRECTORY)
+
+  app.use(function (err, req, res, next) {
+    if (err) {
+      res.status(500).render('includes/error')
+    }
+  })
+  return app
+}

--- a/test/unit/routes/first-time/eligibility/claim/ferry-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/ferry-details.js
@@ -1,0 +1,110 @@
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const supertest = require('supertest')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const ValidationError = require('../../../../../../app/services/errors/validation-error')
+
+describe('routes/first-time/eligibility/claim/ferry-details', function () {
+  const ROUTE = `/first-time-claim/eligibility/A123456/claim/1/ferry`
+
+  var app
+
+  var urlPathValidatorStub
+  var expenseUrlRouterStub
+  var insertExpenseStub
+  var ferryExpenseStub
+
+  beforeEach(function () {
+    urlPathValidatorStub = sinon.stub()
+    expenseUrlRouterStub = sinon.stub()
+    insertExpenseStub = sinon.stub()
+    ferryExpenseStub = sinon.stub()
+
+    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/claim/ferry-details', {
+      '../../../../services/validators/url-path-validator': urlPathValidatorStub,
+      '../../../../services/routing/expenses-url-router': expenseUrlRouterStub,
+      '../../../../services/data/insert-expense': insertExpenseStub,
+      '../../../../services/domain/expenses/ferry-expense': ferryExpenseStub
+    })
+    app = routeHelper.buildApp(route)
+  })
+
+  describe(`GET ${ROUTE}`, function () {
+    it('should call the URL Path Validator', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(200)
+    })
+
+    it('should call parseParams', function () {
+      var parseParams = sinon.stub(expenseUrlRouterStub, 'parseParams')
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(parseParams)
+        })
+    })
+  })
+
+  describe(`POST ${ROUTE}`, function () {
+    const REDIRECT_URL = 'some url'
+    const FERRY_EXPENSE = {}
+
+    it('should call the URL Path Validator', function () {
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 302 if domain object is built and then persisted successfully', function () {
+      ferryExpenseStub.returns(FERRY_EXPENSE)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(ferryExpenseStub)
+          sinon.assert.calledOnce(insertExpenseStub)
+          sinon.assert.calledWith(insertExpenseStub, FERRY_EXPENSE)
+        })
+        .expect(302)
+    })
+
+    it('should call getRedirectUrl and redirect to the url it returns', function () {
+      var getRedirectUrl = sinon.stub(expenseUrlRouterStub, 'getRedirectUrl').returns(REDIRECT_URL)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(getRedirectUrl)
+        })
+        .expect('location', REDIRECT_URL)
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      ferryExpenseStub.throws(new ValidationError())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(400)
+    })
+
+    it('should respond with a 500 if any non-validation error occurs.', function () {
+      ferryExpenseStub.throws(new Error())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(500)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/refreshment-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/refreshment-details.js
@@ -1,0 +1,110 @@
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const supertest = require('supertest')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const ValidationError = require('../../../../../../app/services/errors/validation-error')
+
+describe('routes/first-time/eligibility/claim/light-refreshment-details', function () {
+  const ROUTE = `/first-time-claim/eligibility/A123456/claim/1/refreshment`
+
+  var app
+
+  var urlPathValidatorStub
+  var expenseUrlRouterStub
+  var insertExpenseStub
+  var refreshmentExpenseStub
+
+  beforeEach(function () {
+    urlPathValidatorStub = sinon.stub()
+    expenseUrlRouterStub = sinon.stub()
+    insertExpenseStub = sinon.stub()
+    refreshmentExpenseStub = sinon.stub()
+
+    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/claim/light-refreshment-details', {
+      '../../../../services/validators/url-path-validator': urlPathValidatorStub,
+      '../../../../services/routing/expenses-url-router': expenseUrlRouterStub,
+      '../../../../services/data/insert-expense': insertExpenseStub,
+      '../../../../services/domain/expenses/refreshment-expense': refreshmentExpenseStub
+    })
+    app = routeHelper.buildApp(route)
+  })
+
+  describe(`GET ${ROUTE}`, function () {
+    it('should call the URL Path Validator', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(200)
+    })
+
+    it('should call parseParams', function () {
+      var parseParams = sinon.stub(expenseUrlRouterStub, 'parseParams')
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(parseParams)
+        })
+    })
+  })
+
+  describe(`POST ${ROUTE}`, function () {
+    const REDIRECT_URL = 'some url'
+    const REFRESHMENT_EXPENSE = {}
+
+    it('should call the URL Path Validator', function () {
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 302 if domain object is built and then persisted successfully', function () {
+      refreshmentExpenseStub.returns(REFRESHMENT_EXPENSE)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(refreshmentExpenseStub)
+          sinon.assert.calledOnce(insertExpenseStub)
+          sinon.assert.calledWith(insertExpenseStub, REFRESHMENT_EXPENSE)
+        })
+        .expect(302)
+    })
+
+    it('should call getRedirectUrl and redirect to the url it returns', function () {
+      var getRedirectUrl = sinon.stub(expenseUrlRouterStub, 'getRedirectUrl').returns(REDIRECT_URL)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(getRedirectUrl)
+        })
+        .expect('location', REDIRECT_URL)
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      refreshmentExpenseStub.throws(new ValidationError())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(400)
+    })
+
+    it('should respond with a 500 if any non-validation error occurs.', function () {
+      refreshmentExpenseStub.throws(new Error())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(500)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-accommodation-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-accommodation-details.js
@@ -1,0 +1,110 @@
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const supertest = require('supertest')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const ValidationError = require('../../../../../../app/services/errors/validation-error')
+
+describe('routes/first-time/eligibility/claim/accommodation-details', function () {
+  const ROUTE = `/first-time-claim/eligibility/A123456/claim/1/accommodation`
+
+  var app
+
+  var urlPathValidatorStub
+  var expenseUrlRouterStub
+  var insertExpenseStub
+  var accommodationExpense
+
+  beforeEach(function () {
+    urlPathValidatorStub = sinon.stub()
+    expenseUrlRouterStub = sinon.stub()
+    insertExpenseStub = sinon.stub()
+    accommodationExpense = sinon.stub()
+
+    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/claim/accommodation-details', {
+      '../../../../services/validators/url-path-validator': urlPathValidatorStub,
+      '../../../../services/routing/expenses-url-router': expenseUrlRouterStub,
+      '../../../../services/data/insert-expense': insertExpenseStub,
+      '../../../../services/domain/expenses/accommodation-expense': accommodationExpense
+    })
+    app = routeHelper.buildApp(route)
+  })
+
+  describe(`GET ${ROUTE}`, function () {
+    it('should call the URL Path Validator', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(200)
+    })
+
+    it('should call parseParams', function () {
+      var parseParams = sinon.stub(expenseUrlRouterStub, 'parseParams')
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(parseParams)
+        })
+    })
+  })
+
+  describe(`POST ${ROUTE}`, function () {
+    const REDIRECT_URL = 'some url'
+    const ACCOMMODATION_EXPENSE = {}
+
+    it('should call the URL Path Validator', function () {
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 302 if domain object is built and then persisted successfully', function () {
+      accommodationExpense.returns(ACCOMMODATION_EXPENSE)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(accommodationExpense)
+          sinon.assert.calledOnce(insertExpenseStub)
+          sinon.assert.calledWith(insertExpenseStub, ACCOMMODATION_EXPENSE)
+        })
+        .expect(302)
+    })
+
+    it('should call getRedirectUrl and redirect to the url it returns', function () {
+      var getRedirectUrl = sinon.stub(expenseUrlRouterStub, 'getRedirectUrl').returns(REDIRECT_URL)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(getRedirectUrl)
+        })
+        .expect('location', REDIRECT_URL)
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      accommodationExpense.throws(new ValidationError())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(400)
+    })
+
+    it('should respond with a 500 if any non-validation error occurs.', function () {
+      accommodationExpense.throws(new Error())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(500)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-bus-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-bus-details.js
@@ -1,0 +1,110 @@
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const supertest = require('supertest')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const ValidationError = require('../../../../../../app/services/errors/validation-error')
+
+describe('routes/first-time/eligibility/claim/bus-details', function () {
+  const ROUTE = `/first-time-claim/eligibility/A123456/claim/1/bus`
+
+  var app
+
+  var urlPathValidatorStub
+  var expenseUrlRouterStub
+  var insertExpenseStub
+  var busExpenseStub
+
+  beforeEach(function () {
+    urlPathValidatorStub = sinon.stub()
+    expenseUrlRouterStub = sinon.stub()
+    insertExpenseStub = sinon.stub()
+    busExpenseStub = sinon.stub()
+
+    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/claim/bus-details', {
+      '../../../../services/validators/url-path-validator': urlPathValidatorStub,
+      '../../../../services/routing/expenses-url-router': expenseUrlRouterStub,
+      '../../../../services/data/insert-expense': insertExpenseStub,
+      '../../../../services/domain/expenses/bus-expense': busExpenseStub
+    })
+    app = routeHelper.buildApp(route)
+  })
+
+  describe(`GET ${ROUTE}`, function () {
+    it('should call the URL Path Validator', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(200)
+    })
+
+    it('should call parseParams', function () {
+      var parseParams = sinon.stub(expenseUrlRouterStub, 'parseParams')
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(parseParams)
+        })
+    })
+  })
+
+  describe(`POST ${ROUTE}`, function () {
+    const REDIRECT_URL = 'some url'
+    const BUS_EXPENSE = {}
+
+    it('should call the URL Path Validator', function () {
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 302 if domain object is built and then persisted successfully', function () {
+      busExpenseStub.returns(BUS_EXPENSE)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(busExpenseStub)
+          sinon.assert.calledOnce(insertExpenseStub)
+          sinon.assert.calledWith(insertExpenseStub, BUS_EXPENSE)
+        })
+        .expect(302)
+    })
+
+    it('should call getRedirectUrl and redirect to the url it returns', function () {
+      var getRedirectUrl = sinon.stub(expenseUrlRouterStub, 'getRedirectUrl').returns(REDIRECT_URL)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(getRedirectUrl)
+        })
+        .expect('location', REDIRECT_URL)
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      busExpenseStub.throws(new ValidationError())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(400)
+    })
+
+    it('should respond with a 500 if any non-validation error occurs.', function () {
+      busExpenseStub.throws(new Error())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(500)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-car-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-car-details.js
@@ -1,0 +1,115 @@
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const supertest = require('supertest')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const ValidationError = require('../../../../../../app/services/errors/validation-error')
+
+describe('routes/first-time/eligibility/claim/car-details', function () {
+  const ROUTE = `/first-time-claim/eligibility/A123456/claim/1/car`
+
+  var app
+
+  var urlPathValidatorStub
+  var expenseUrlRouterStub
+  var insertCarExpensesStub
+  var getTravellingFromAndToStub
+  var carExpenseStub
+
+  beforeEach(function () {
+    urlPathValidatorStub = sinon.stub()
+    expenseUrlRouterStub = sinon.stub()
+    insertCarExpensesStub = sinon.stub()
+    getTravellingFromAndToStub = sinon.stub()
+    carExpenseStub = sinon.stub()
+
+    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/claim/car-details', {
+      '../../../../services/validators/url-path-validator': urlPathValidatorStub,
+      '../../../../services/routing/expenses-url-router': expenseUrlRouterStub,
+      '../../../../services/data/insert-car-expenses': insertCarExpensesStub,
+      '../../../../services/data/get-travelling-from-and-to': getTravellingFromAndToStub,
+      '../../../../services/domain/expenses/car-expense': carExpenseStub
+    })
+    app = routeHelper.buildApp(route)
+  })
+
+  describe(`GET ${ROUTE}`, function () {
+    it('should call the URL Path Validator', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 200', function () {
+      getTravellingFromAndToStub.resolves()
+      return supertest(app)
+        .get(ROUTE)
+        .expect(200)
+    })
+
+    it('should call parseParams', function () {
+      getTravellingFromAndToStub.resolves()
+      var parseParams = sinon.stub(expenseUrlRouterStub, 'parseParams')
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(parseParams)
+        })
+    })
+  })
+
+  describe(`POST ${ROUTE}`, function () {
+    const REDIRECT_URL = 'some url'
+    const CAR_EXPENSE = {}
+
+    it('should call the URL Path Validator', function () {
+      insertCarExpensesStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 302 if domain object is built and then persisted successfully', function () {
+      carExpenseStub.returns(CAR_EXPENSE)
+      insertCarExpensesStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(carExpenseStub)
+          sinon.assert.calledOnce(insertCarExpensesStub)
+          sinon.assert.calledWith(insertCarExpensesStub, CAR_EXPENSE)
+        })
+        .expect(302)
+    })
+
+    it('should call getRedirectUrl and redirect to the url it returns', function () {
+      var getRedirectUrl = sinon.stub(expenseUrlRouterStub, 'getRedirectUrl').returns(REDIRECT_URL)
+      insertCarExpensesStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(getRedirectUrl)
+        })
+        .expect('location', REDIRECT_URL)
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      carExpenseStub.throws(new ValidationError())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(400)
+    })
+
+    it('should respond with a 500 if any non-validation error occurs.', function () {
+      carExpenseStub.throws(new Error())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(500)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-hire-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-hire-details.js
@@ -1,0 +1,110 @@
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const supertest = require('supertest')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const ValidationError = require('../../../../../../app/services/errors/validation-error')
+
+describe('routes/first-time/eligibility/claim/car-hire-details', function () {
+  const ROUTE = `/first-time-claim/eligibility/A123456/claim/1/hire`
+
+  var app
+
+  var urlPathValidatorStub
+  var expenseUrlRouterStub
+  var insertExpenseStub
+  var hireExpenseStub
+
+  beforeEach(function () {
+    urlPathValidatorStub = sinon.stub()
+    expenseUrlRouterStub = sinon.stub()
+    insertExpenseStub = sinon.stub()
+    hireExpenseStub = sinon.stub()
+
+    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/claim/car-hire-details', {
+      '../../../../services/validators/url-path-validator': urlPathValidatorStub,
+      '../../../../services/routing/expenses-url-router': expenseUrlRouterStub,
+      '../../../../services/data/insert-expense': insertExpenseStub,
+      '../../../../services/domain/expenses/hire-expense': hireExpenseStub
+    })
+    app = routeHelper.buildApp(route)
+  })
+
+  describe(`GET ${ROUTE}`, function () {
+    it('should call the URL Path Validator', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(200)
+    })
+
+    it('should call parseParams', function () {
+      var parseParams = sinon.stub(expenseUrlRouterStub, 'parseParams')
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(parseParams)
+        })
+    })
+  })
+
+  describe(`POST ${ROUTE}`, function () {
+    const REDIRECT_URL = 'some url'
+    const HIRE_EXPENSE = {}
+
+    it('should call the URL Path Validator', function () {
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 302 if domain object is built and then persisted successfully', function () {
+      hireExpenseStub.returns(HIRE_EXPENSE)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(hireExpenseStub)
+          sinon.assert.calledOnce(insertExpenseStub)
+          sinon.assert.calledWith(insertExpenseStub, HIRE_EXPENSE)
+        })
+        .expect(302)
+    })
+
+    it('should call getRedirectUrl and redirect to the url it returns', function () {
+      var getRedirectUrl = sinon.stub(expenseUrlRouterStub, 'getRedirectUrl').returns(REDIRECT_URL)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(getRedirectUrl)
+        })
+        .expect('location', REDIRECT_URL)
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      hireExpenseStub.throws(new ValidationError())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(400)
+    })
+
+    it('should respond with a 500 if any non-validation error occurs.', function () {
+      hireExpenseStub.throws(new Error())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(500)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-plene-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-plene-details.js
@@ -1,0 +1,110 @@
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const supertest = require('supertest')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const ValidationError = require('../../../../../../app/services/errors/validation-error')
+
+describe('routes/first-time/eligibility/claim/plane-details', function () {
+  const ROUTE = `/first-time-claim/eligibility/A123456/claim/1/plane`
+
+  var app
+
+  var urlPathValidatorStub
+  var expenseUrlRouterStub
+  var insertExpenseStub
+  var planeExpenseStub
+
+  beforeEach(function () {
+    urlPathValidatorStub = sinon.stub()
+    expenseUrlRouterStub = sinon.stub()
+    insertExpenseStub = sinon.stub()
+    planeExpenseStub = sinon.stub()
+
+    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/claim/plane-details', {
+      '../../../../services/validators/url-path-validator': urlPathValidatorStub,
+      '../../../../services/routing/expenses-url-router': expenseUrlRouterStub,
+      '../../../../services/data/insert-expense': insertExpenseStub,
+      '../../../../services/domain/expenses/plane-expense': planeExpenseStub
+    })
+    app = routeHelper.buildApp(route)
+  })
+
+  describe(`GET ${ROUTE}`, function () {
+    it('should call the URL Path Validator', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(200)
+    })
+
+    it('should call parseParams', function () {
+      var parseParams = sinon.stub(expenseUrlRouterStub, 'parseParams')
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(parseParams)
+        })
+    })
+  })
+
+  describe(`POST ${ROUTE}`, function () {
+    const REDIRECT_URL = 'some url'
+    const PLANE_EXPENSE = {}
+
+    it('should call the URL Path Validator', function () {
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 302 if domain object is built and then persisted successfully', function () {
+      planeExpenseStub.returns(PLANE_EXPENSE)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(planeExpenseStub)
+          sinon.assert.calledOnce(insertExpenseStub)
+          sinon.assert.calledWith(insertExpenseStub, PLANE_EXPENSE)
+        })
+        .expect(302)
+    })
+
+    it('should call getRedirectUrl and redirect to the url it returns', function () {
+      var getRedirectUrl = sinon.stub(expenseUrlRouterStub, 'getRedirectUrl').returns(REDIRECT_URL)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(getRedirectUrl)
+        })
+        .expect('location', REDIRECT_URL)
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      planeExpenseStub.throws(new ValidationError())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(400)
+    })
+
+    it('should respond with a 500 if any non-validation error occurs.', function () {
+      planeExpenseStub.throws(new Error())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(500)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-taxi-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-taxi-details.js
@@ -1,0 +1,110 @@
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const supertest = require('supertest')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const ValidationError = require('../../../../../../app/services/errors/validation-error')
+
+describe('routes/first-time/eligibility/claim/taxi-details', function () {
+  const ROUTE = `/first-time-claim/eligibility/A123456/claim/1/taxi`
+
+  var app
+
+  var urlPathValidatorStub
+  var expenseUrlRouterStub
+  var insertExpenseStub
+  var taxiExpenseStub
+
+  beforeEach(function () {
+    urlPathValidatorStub = sinon.stub()
+    expenseUrlRouterStub = sinon.stub()
+    insertExpenseStub = sinon.stub()
+    taxiExpenseStub = sinon.stub()
+
+    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/claim/taxi-details', {
+      '../../../../services/validators/url-path-validator': urlPathValidatorStub,
+      '../../../../services/routing/expenses-url-router': expenseUrlRouterStub,
+      '../../../../services/data/insert-expense': insertExpenseStub,
+      '../../../../services/domain/expenses/taxi-expense': taxiExpenseStub
+    })
+    app = routeHelper.buildApp(route)
+  })
+
+  describe(`GET ${ROUTE}`, function () {
+    it('should call the URL Path Validator', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(200)
+    })
+
+    it('should call parseParams', function () {
+      var parseParams = sinon.stub(expenseUrlRouterStub, 'parseParams')
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(parseParams)
+        })
+    })
+  })
+
+  describe(`POST ${ROUTE}`, function () {
+    const REDIRECT_URL = 'some url'
+    const TAXI_EXPENSE = {}
+
+    it('should call the URL Path Validator', function () {
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 302 if domain object is built and then persisted successfully', function () {
+      taxiExpenseStub.returns(TAXI_EXPENSE)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(taxiExpenseStub)
+          sinon.assert.calledOnce(insertExpenseStub)
+          sinon.assert.calledWith(insertExpenseStub, TAXI_EXPENSE)
+        })
+        .expect(302)
+    })
+
+    it('should call getRedirectUrl and redirect to the url it returns', function () {
+      var getRedirectUrl = sinon.stub(expenseUrlRouterStub, 'getRedirectUrl').returns(REDIRECT_URL)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(getRedirectUrl)
+        })
+        .expect('location', REDIRECT_URL)
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      taxiExpenseStub.throws(new ValidationError())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(400)
+    })
+
+    it('should respond with a 500 if any non-validation error occurs.', function () {
+      taxiExpenseStub.throws(new Error())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(500)
+    })
+  })
+})

--- a/test/unit/routes/first-time/eligibility/claim/test-train-details.js
+++ b/test/unit/routes/first-time/eligibility/claim/test-train-details.js
@@ -1,0 +1,110 @@
+const routeHelper = require('../../../../../helpers/routes/route-helper')
+const supertest = require('supertest')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+require('sinon-bluebird')
+
+const ValidationError = require('../../../../../../app/services/errors/validation-error')
+
+describe('routes/first-time/eligibility/claim/train-details', function () {
+  const ROUTE = `/first-time-claim/eligibility/A123456/claim/1/train`
+
+  var app
+
+  var urlPathValidatorStub
+  var expenseUrlRouterStub
+  var insertExpenseStub
+  var trainExpenseStub
+
+  beforeEach(function () {
+    urlPathValidatorStub = sinon.stub()
+    expenseUrlRouterStub = sinon.stub()
+    insertExpenseStub = sinon.stub()
+    trainExpenseStub = sinon.stub()
+
+    var route = proxyquire('../../../../../../app/routes/first-time/eligibility/claim/train-details', {
+      '../../../../services/validators/url-path-validator': urlPathValidatorStub,
+      '../../../../services/routing/expenses-url-router': expenseUrlRouterStub,
+      '../../../../services/data/insert-expense': insertExpenseStub,
+      '../../../../services/domain/expenses/train-expense': trainExpenseStub
+    })
+    app = routeHelper.buildApp(route)
+  })
+
+  describe(`GET ${ROUTE}`, function () {
+    it('should call the URL Path Validator', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(200)
+    })
+
+    it('should call parseParams', function () {
+      var parseParams = sinon.stub(expenseUrlRouterStub, 'parseParams')
+      return supertest(app)
+        .get(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(parseParams)
+        })
+    })
+  })
+
+  describe(`POST ${ROUTE}`, function () {
+    const REDIRECT_URL = 'some url'
+    const TRAIN_EXPENSE = {}
+
+    it('should call the URL Path Validator', function () {
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(urlPathValidatorStub)
+        })
+    })
+
+    it('should respond with a 302 if domain object is built and then persisted successfully', function () {
+      trainExpenseStub.returns(TRAIN_EXPENSE)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(trainExpenseStub)
+          sinon.assert.calledOnce(insertExpenseStub)
+          sinon.assert.calledWith(insertExpenseStub, TRAIN_EXPENSE)
+        })
+        .expect(302)
+    })
+
+    it('should call getRedirectUrl and redirect to the url it returns', function () {
+      var getRedirectUrl = sinon.stub(expenseUrlRouterStub, 'getRedirectUrl').returns(REDIRECT_URL)
+      insertExpenseStub.resolves()
+      return supertest(app)
+        .post(ROUTE)
+        .expect(function () {
+          sinon.assert.calledOnce(getRedirectUrl)
+        })
+        .expect('location', REDIRECT_URL)
+    })
+
+    it('should respond with a 400 if domain object validation fails.', function () {
+      trainExpenseStub.throws(new ValidationError())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(400)
+    })
+
+    it('should respond with a 500 if any non-validation error occurs.', function () {
+      trainExpenseStub.throws(new Error())
+      return supertest(app)
+        .post(ROUTE)
+        .expect(500)
+    })
+  })
+})

--- a/test/unit/services/routing/test-expenses-url-router.js
+++ b/test/unit/services/routing/test-expenses-url-router.js
@@ -5,17 +5,19 @@ const paramBuilder = require('../../../../app/services/routing/param-builder')
 
 describe('services/routing/expenses-url-router', function () {
   describe('parseParams', function () {
-    var buildFormatted = sinon.stub(paramBuilder, 'buildFormatted')
+    var buildFormatted
 
-    it('should call buildFormatted to build and format the params parameter', function (done) {
-      expensesUrlRouter.parseParams([])
-      sinon.assert.calledOnce(buildFormatted)
-      done()
+    before(function () {
+      buildFormatted = sinon.stub(paramBuilder, 'buildFormatted')
     })
 
-    after(function (done) {
+    after(function () {
       buildFormatted.restore()
-      done()
+    })
+
+    it('should call buildFormatted to build and format the params parameter', function () {
+      expensesUrlRouter.parseParams([])
+      sinon.assert.calledOnce(buildFormatted)
     })
   })
 


### PR DESCRIPTION
- Added route tests for each of the expense pages.
- Added a route-helper that encapsulates the boiler plate route test setup.
- Added afterEach to package.json

## Checklist

- [x] Unit tests
- [x] End-to-End tests
- [x] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated