### PR TITLE
Added the ability to add child expenses to the bus, ferry, plane, and…

### DIFF
--- a/app/routes/first-time/eligibility/claim/bus-details.js
+++ b/app/routes/first-time/eligibility/claim/bus-details.js
@@ -23,7 +23,8 @@ module.exports = function (router) {
         req.body.cost,
         req.body.from,
         req.body.to,
-        req.body['return-journey']
+        req.body['return-journey'],
+        req.body['is-child']
       )
 
       insertExpense(expense)

--- a/app/routes/first-time/eligibility/claim/ferry-details.js
+++ b/app/routes/first-time/eligibility/claim/ferry-details.js
@@ -24,7 +24,8 @@ module.exports = function (router) {
         req.body.from,
         req.body.to,
         req.body['return-journey'],
-        req.body['ticket-type']
+        req.body['ticket-type'],
+        req.body['is-child']
       )
 
       insertExpense(expense)

--- a/app/routes/first-time/eligibility/claim/plane-details.js
+++ b/app/routes/first-time/eligibility/claim/plane-details.js
@@ -23,7 +23,8 @@ module.exports = function (router) {
         req.body.cost,
         req.body.from,
         req.body.to,
-        req.body['return-journey']
+        req.body['return-journey'],
+        req.body['is-child']
       )
 
       insertExpense(expense)

--- a/app/routes/first-time/eligibility/claim/train-details.js
+++ b/app/routes/first-time/eligibility/claim/train-details.js
@@ -23,7 +23,8 @@ module.exports = function (router) {
         req.body.cost,
         req.body.from,
         req.body.to,
-        req.body['return-journey']
+        req.body['return-journey'],
+        req.body['is-child']
       )
 
       insertExpense(expense)

--- a/app/services/data/insert-expense.js
+++ b/app/services/data/insert-expense.js
@@ -1,9 +1,9 @@
 const config = require('../../../knexfile').extweb
 const knex = require('knex')(config)
-const ExpenseBase = require('../../services/domain/expenses/base-expense')
+const BaseExpense = require('../../services/domain/expenses/base-expense')
 
 module.exports = function (expense) {
-  if (!(expense instanceof ExpenseBase)) {
+  if (!(expense instanceof BaseExpense)) {
     throw new Error('Provided object is not an instance of the expected class')
   }
 

--- a/app/services/data/insert-expense.js
+++ b/app/services/data/insert-expense.js
@@ -16,6 +16,7 @@ module.exports = function (expense) {
     To: expense.to || null,
     IsReturn: expense.isReturn === 'yes',
     DurationOfTravel: expense.durationOfTravel || null,
-    TicketType: expense.ticketType || null
+    TicketType: expense.ticketType || null,
+    IsChild: expense.isChild === 'yes'
   })
 }

--- a/app/services/domain/expenses/accommodation-expense.js
+++ b/app/services/domain/expenses/accommodation-expense.js
@@ -6,7 +6,7 @@ const ErrorHandler = require('../../validators/error-handler')
 
 class AccommodationExpense extends BaseExpense {
   constructor (claimId, cost, durationOfTravel) {
-    super(claimId, EXPENSE_TYPE.ACCOMMODATION, cost, null, null, null, null, durationOfTravel, null)
+    super(claimId, EXPENSE_TYPE.ACCOMMODATION, cost, null, null, null, null, durationOfTravel, null, null)
     this.isValid()
   }
 

--- a/app/services/domain/expenses/base-expense.js
+++ b/app/services/domain/expenses/base-expense.js
@@ -2,7 +2,7 @@
  * This is a base class for all of the expense domain objects.
  */
 class ExpenseBase {
-  constructor (claimId, expenseType, cost, travelTime, from, to, isReturn, durationOfTravel, ticketType) {
+  constructor (claimId, expenseType, cost, travelTime, from, to, isReturn, durationOfTravel, ticketType, isChild) {
     this.createField('claimId', claimId)
     this.createField('expenseType', expenseType)
     this.createField('cost', cost)
@@ -12,6 +12,7 @@ class ExpenseBase {
     this.createField('isReturn', isReturn)
     this.createField('durationOfTravel', durationOfTravel)
     this.createField('ticketType', ticketType)
+    this.createField('isChild', isChild)
   }
 
   createField (key, value) {

--- a/app/services/domain/expenses/base-expense.js
+++ b/app/services/domain/expenses/base-expense.js
@@ -1,7 +1,7 @@
 /**
  * This is a base class for all of the expense domain objects.
  */
-class ExpenseBase {
+class BaseExpense {
   constructor (claimId, expenseType, cost, travelTime, from, to, isReturn, durationOfTravel, ticketType, isChild) {
     this.createField('claimId', claimId)
     this.createField('expenseType', expenseType)
@@ -20,4 +20,4 @@ class ExpenseBase {
   }
 }
 
-module.exports = ExpenseBase
+module.exports = BaseExpense

--- a/app/services/domain/expenses/bus-expense.js
+++ b/app/services/domain/expenses/bus-expense.js
@@ -5,8 +5,8 @@ const FieldValidator = require('../../validators/field-validator')
 const ErrorHandler = require('../../validators/error-handler')
 
 class BusExpense extends BaseExpense {
-  constructor (claimId, cost, from, to, isReturn) {
-    super(claimId, EXPENSE_TYPE.BUS, cost, null, from, to, isReturn, null, null)
+  constructor (claimId, cost, from, to, isReturn, isChild) {
+    super(claimId, EXPENSE_TYPE.BUS, cost, null, from, to, isReturn, null, null, isChild)
     this.isValid()
   }
 
@@ -22,6 +22,9 @@ class BusExpense extends BaseExpense {
       .isLessThanLength(100)
 
     FieldValidator(this.isReturn, 'return-journey', errors)
+      .isRequired()
+
+    FieldValidator(this.isChild, 'is-child', errors)
       .isRequired()
 
     FieldValidator(this.cost, 'cost', errors)

--- a/app/services/domain/expenses/car-expense.js
+++ b/app/services/domain/expenses/car-expense.js
@@ -6,7 +6,7 @@ const ErrorHandler = require('../../validators/error-handler')
 
 class CarExpense extends BaseExpense {
   constructor (claimId, from, to, toll, tollCost, parking, parkingCost) {
-    super(claimId, EXPENSE_TYPE.CAR, null, null, from, to, null, null, null)
+    super(claimId, EXPENSE_TYPE.CAR, null, null, from, to, null, null, null, null)
     this.toll = toll
     this.createField('tollCost', tollCost)
     this.parking = parking

--- a/app/services/domain/expenses/ferry-expense.js
+++ b/app/services/domain/expenses/ferry-expense.js
@@ -5,8 +5,8 @@ const FieldValidator = require('../../validators/field-validator')
 const ErrorHandler = require('../../validators/error-handler')
 
 class FerryExpense extends BaseExpense {
-  constructor (claimId, cost, from, to, returnJourney, ticketType) {
-    super(claimId, EXPENSE_TYPE.FERRY, cost, null, from, to, returnJourney, null, ticketType)
+  constructor (claimId, cost, from, to, returnJourney, ticketType, isChild) {
+    super(claimId, EXPENSE_TYPE.FERRY, cost, null, from, to, returnJourney, null, ticketType, isChild)
     this.isValid()
   }
 
@@ -22,6 +22,9 @@ class FerryExpense extends BaseExpense {
       .isLessThanLength(100)
 
     FieldValidator(this.isReturn, 'return-journey', errors)
+      .isRequired()
+
+    FieldValidator(this.isChild, 'is-child', errors)
       .isRequired()
 
     FieldValidator(this.ticketType, 'ticket-type', errors)

--- a/app/services/domain/expenses/hire-expense.js
+++ b/app/services/domain/expenses/hire-expense.js
@@ -6,7 +6,7 @@ const ErrorHandler = require('../../validators/error-handler')
 
 class HireExpense extends BaseExpense {
   constructor (claimId, cost, from, to, durationOfTravel) {
-    super(claimId, EXPENSE_TYPE.CAR_HIRE, cost, null, from, to, null, durationOfTravel, null)
+    super(claimId, EXPENSE_TYPE.CAR_HIRE, cost, null, from, to, null, durationOfTravel, null, null)
     this.isValid()
   }
 

--- a/app/services/domain/expenses/plane-expense.js
+++ b/app/services/domain/expenses/plane-expense.js
@@ -5,8 +5,8 @@ const FieldValidator = require('../../validators/field-validator')
 const ErrorHandler = require('../../validators/error-handler')
 
 class PlaneExpense extends BaseExpense {
-  constructor (claimId, cost, from, to, isReturn) {
-    super(claimId, EXPENSE_TYPE.PLANE, cost, null, from, to, isReturn, null, null)
+  constructor (claimId, cost, from, to, isReturn, isChild) {
+    super(claimId, EXPENSE_TYPE.PLANE, cost, null, from, to, isReturn, null, null, isChild)
     this.isValid()
   }
 
@@ -22,6 +22,9 @@ class PlaneExpense extends BaseExpense {
       .isLessThanLength(100)
 
     FieldValidator(this.isReturn, 'return-journey', errors)
+      .isRequired()
+
+    FieldValidator(this.isChild, 'is-child', errors)
       .isRequired()
 
     FieldValidator(this.cost, 'cost', errors)

--- a/app/services/domain/expenses/refreshment-expense.js
+++ b/app/services/domain/expenses/refreshment-expense.js
@@ -6,7 +6,7 @@ const ErrorHandler = require('../../validators/error-handler')
 
 class RefreshmentExpense extends BaseExpense {
   constructor (claimId, cost, travelTime) {
-    super(claimId, EXPENSE_TYPE.LIGHT_REFRESHMENT, cost, travelTime, null, null, null, null, null)
+    super(claimId, EXPENSE_TYPE.LIGHT_REFRESHMENT, cost, travelTime, null, null, null, null, null, null)
     this.isValid()
   }
 

--- a/app/services/domain/expenses/taxi-expense.js
+++ b/app/services/domain/expenses/taxi-expense.js
@@ -6,7 +6,7 @@ const ErrorHandler = require('../../validators/error-handler')
 
 class TaxiExpense extends BaseExpense {
   constructor (claimId, cost, from, to) {
-    super(claimId, EXPENSE_TYPE.TAXI, cost, null, from, to, null, null, null)
+    super(claimId, EXPENSE_TYPE.TAXI, cost, null, from, to, null, null, null, null)
     this.isValid()
   }
 

--- a/app/services/domain/expenses/train-expense.js
+++ b/app/services/domain/expenses/train-expense.js
@@ -5,8 +5,8 @@ const FieldValidator = require('../../validators/field-validator')
 const ErrorHandler = require('../../validators/error-handler')
 
 class TrainExpense extends BaseExpense {
-  constructor (claimId, cost, from, to, isReturn) {
-    super(claimId, EXPENSE_TYPE.TRAIN, cost, null, from, to, isReturn, null, null)
+  constructor (claimId, cost, from, to, isReturn, isChild) {
+    super(claimId, EXPENSE_TYPE.TRAIN, cost, null, from, to, isReturn, null, null, isChild)
     this.isValid()
   }
 
@@ -22,6 +22,9 @@ class TrainExpense extends BaseExpense {
       .isLessThanLength(100)
 
     FieldValidator(this.isReturn, 'return-journey', errors)
+      .isRequired()
+
+    FieldValidator(this.isChild, 'is-child', errors)
       .isRequired()
 
     FieldValidator(this.cost, 'cost', errors)

--- a/app/services/validators/validation-field-names.js
+++ b/app/services/validators/validation-field-names.js
@@ -31,5 +31,6 @@ module.exports = {
   'duration': 'Travel Duration',
   'ticket-type': 'Ticket Type',
   'toll-cost': 'Toll Cost',
-  'parking-charge-cost': 'Parking Charge Cost'
+  'parking-charge-cost': 'Parking Charge Cost',
+  'is-child': 'Child Expense'
 }

--- a/app/views/first-time/eligibility/claim/bus-details.html
+++ b/app/views/first-time/eligibility/claim/bus-details.html
@@ -85,7 +85,7 @@
 
           <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
 
-            <h2 id="is-child" class="form-label-bold">Is this an expense for your child?</h2>
+            <h2 id="is-child" class="form-label-bold">Is this a child ticket?</h2>
 
             {% if errors['is-child'][0] %}
               <span class="error-message">{{ errors['is-child'][0] }}</span>

--- a/app/views/first-time/eligibility/claim/bus-details.html
+++ b/app/views/first-time/eligibility/claim/bus-details.html
@@ -53,35 +53,7 @@
 
         <div class="form-group">
 
-          <div class="form-group {% if errors['return-journey'][0] %} error {% endif %}">
-
-            <h2 id="return-journey" class="form-label-bold">Is this a return journey?</h2>
-
-            {% if errors['return-journey'][0] %}
-              <span class="error-message">{{ errors['return-journey'][0] }}</span>
-            {% endif %}
-
-            <fieldset>
-
-              <label for="return-yes" class="block-label inline">
-                <input id="return-yes"
-                       type="radio"
-                       name="return-journey"
-                       value="yes"
-                       {% if expense['return-journey'] == 'yes' %} checked {% endif %}>
-                Yes
-              </label>
-              <label for="return-no" class="block-label inline">
-                <input id="return-no"
-                       type="radio"
-                       name="return-journey"
-                       value="no"
-                       {% if expense['return-journey'] == 'no' %} checked {% endif %}>
-                No
-              </label>
-
-            </fieldset>
-          </div>
+          {% include "partials/expenses/return-journey.html" %}
 
           {% include "partials/expenses/is-child.html" %}
 

--- a/app/views/first-time/eligibility/claim/bus-details.html
+++ b/app/views/first-time/eligibility/claim/bus-details.html
@@ -83,6 +83,36 @@
             </fieldset>
           </div>
 
+          <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
+
+            <h2 id="is-child" class="form-label-bold">Is this an expense for your child?</h2>
+
+            {% if errors['is-child'][0] %}
+              <span class="error-message">{{ errors['is-child'][0] }}</span>
+            {% endif %}
+
+            <fieldset>
+
+              <label for="is-child-yes" class="block-label inline">
+                <input id="is-child-yes"
+                       type="radio"
+                       name="is-child"
+                       value="yes"
+                       {% if expense['is-child'] == 'yes' %} checked {% endif %}>
+                Yes
+              </label>
+              <label for="is-child-no" class="block-label inline">
+                <input id="is-child-no"
+                       type="radio"
+                       name="is-child"
+                       value="no"
+                       {% if expense['is-child'] == 'no' %} checked {% endif %}>
+                No
+              </label>
+
+            </fieldset>
+          </div>
+
           <div class="form-group {% if errors['cost'][0] %} error {% endif %}">
             <label id="cost" for="cost-input" class="form-label-bold">Cost</label>
 

--- a/app/views/first-time/eligibility/claim/bus-details.html
+++ b/app/views/first-time/eligibility/claim/bus-details.html
@@ -83,35 +83,7 @@
             </fieldset>
           </div>
 
-          <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
-
-            <h2 id="is-child" class="form-label-bold">Is this a child ticket?</h2>
-
-            {% if errors['is-child'][0] %}
-              <span class="error-message">{{ errors['is-child'][0] }}</span>
-            {% endif %}
-
-            <fieldset>
-
-              <label for="is-child-yes" class="block-label inline">
-                <input id="is-child-yes"
-                       type="radio"
-                       name="is-child"
-                       value="yes"
-                       {% if expense['is-child'] == 'yes' %} checked {% endif %}>
-                Yes
-              </label>
-              <label for="is-child-no" class="block-label inline">
-                <input id="is-child-no"
-                       type="radio"
-                       name="is-child"
-                       value="no"
-                       {% if expense['is-child'] == 'no' %} checked {% endif %}>
-                No
-              </label>
-
-            </fieldset>
-          </div>
+          {% include "partials/expenses/is-child.html" %}
 
           <div class="form-group {% if errors['cost'][0] %} error {% endif %}">
             <label id="cost" for="cost-input" class="form-label-bold">Cost</label>

--- a/app/views/first-time/eligibility/claim/ferry-details.html
+++ b/app/views/first-time/eligibility/claim/ferry-details.html
@@ -86,6 +86,36 @@
             </fieldset>
           </div>
 
+          <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
+
+            <h2 id="is-child" class="form-label-bold">Is this an expense for your child?</h2>
+
+            {% if errors['is-child'][0] %}
+              <span class="error-message">{{ errors['is-child'][0] }}</span>
+            {% endif %}
+
+            <fieldset>
+
+              <label for="is-child-yes" class="block-label inline">
+                <input id="is-child-yes"
+                       type="radio"
+                       name="is-child"
+                       value="yes"
+                       {% if expense['is-child'] == 'yes' %} checked {% endif %}>
+                Yes
+              </label>
+              <label for="is-child-no" class="block-label inline">
+                <input id="is-child-no"
+                       type="radio"
+                       name="is-child"
+                       value="no"
+                       {% if expense['is-child'] == 'no' %} checked {% endif %}>
+                No
+              </label>
+
+            </fieldset>
+          </div>
+
           <div class="form-group {% if errors['ticket-type'][0] %} error {% endif %}">
 
             <h2 id="ticket-type" class="form-label-bold">Ticket type</h2>

--- a/app/views/first-time/eligibility/claim/ferry-details.html
+++ b/app/views/first-time/eligibility/claim/ferry-details.html
@@ -88,7 +88,7 @@
 
           <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
 
-            <h2 id="is-child" class="form-label-bold">Is this an expense for your child?</h2>
+            <h2 id="is-child" class="form-label-bold">Is this a child ticket?</h2>
 
             {% if errors['is-child'][0] %}
               <span class="error-message">{{ errors['is-child'][0] }}</span>

--- a/app/views/first-time/eligibility/claim/ferry-details.html
+++ b/app/views/first-time/eligibility/claim/ferry-details.html
@@ -56,35 +56,7 @@
 
         <div class="form-group">
 
-          <div class="form-group {% if errors['return-journey'][0] %} error {% endif %}">
-
-            <h2 id="return-journey" class="form-label-bold">Is this a return journey?</h2>
-
-            {% if errors['return-journey'][0] %}
-              <span class="error-message">{{ errors['return-journey'][0] }}</span>
-            {% endif %}
-
-            <fieldset>
-
-              <label for="return-yes" class="block-label inline">
-                <input id="return-yes"
-                       type="radio"
-                       name="return-journey"
-                       value="yes"
-                       {% if expense['return-journey'] == 'yes' %} checked {% endif %}>
-                Yes
-              </label>
-              <label for="return-no" class="block-label inline">
-                <input id="return-no"
-                       type="radio"
-                       name="return-journey"
-                       value="no"
-                       {% if expense['return-journey'] == 'no' %} checked {% endif %}>
-                No
-              </label>
-
-            </fieldset>
-          </div>
+          {% include "partials/expenses/return-journey.html" %}
 
           {% include "partials/expenses/is-child.html" %}
 

--- a/app/views/first-time/eligibility/claim/ferry-details.html
+++ b/app/views/first-time/eligibility/claim/ferry-details.html
@@ -86,35 +86,7 @@
             </fieldset>
           </div>
 
-          <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
-
-            <h2 id="is-child" class="form-label-bold">Is this a child ticket?</h2>
-
-            {% if errors['is-child'][0] %}
-              <span class="error-message">{{ errors['is-child'][0] }}</span>
-            {% endif %}
-
-            <fieldset>
-
-              <label for="is-child-yes" class="block-label inline">
-                <input id="is-child-yes"
-                       type="radio"
-                       name="is-child"
-                       value="yes"
-                       {% if expense['is-child'] == 'yes' %} checked {% endif %}>
-                Yes
-              </label>
-              <label for="is-child-no" class="block-label inline">
-                <input id="is-child-no"
-                       type="radio"
-                       name="is-child"
-                       value="no"
-                       {% if expense['is-child'] == 'no' %} checked {% endif %}>
-                No
-              </label>
-
-            </fieldset>
-          </div>
+          {% include "partials/expenses/is-child.html" %}
 
           <div class="form-group {% if errors['ticket-type'][0] %} error {% endif %}">
 

--- a/app/views/first-time/eligibility/claim/plane-details.html
+++ b/app/views/first-time/eligibility/claim/plane-details.html
@@ -87,35 +87,7 @@
             </fieldset>
           </div>
 
-          <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
-
-            <h2 id="is-child" class="form-label-bold">Is this a child ticket?</h2>
-
-            {% if errors['is-child'][0] %}
-              <span class="error-message">{{ errors['is-child'][0] }}</span>
-            {% endif %}
-
-            <fieldset>
-
-              <label for="is-child-yes" class="block-label inline">
-                <input id="is-child-yes"
-                       type="radio"
-                       name="is-child"
-                       value="yes"
-                       {% if expense['is-child'] == 'yes' %} checked {% endif %}>
-                Yes
-              </label>
-              <label for="is-child-no" class="block-label inline">
-                <input id="is-child-no"
-                       type="radio"
-                       name="is-child"
-                       value="no"
-                       {% if expense['is-child'] == 'no' %} checked {% endif %}>
-                No
-              </label>
-
-            </fieldset>
-          </div>
+          {% include "partials/expenses/is-child.html" %}
 
           <div class="form-group {% if errors['cost'][0] %} error {% endif %}">
             <label id="cost" for="cost-input" class="form-label-bold">Cost</label>

--- a/app/views/first-time/eligibility/claim/plane-details.html
+++ b/app/views/first-time/eligibility/claim/plane-details.html
@@ -87,6 +87,36 @@
             </fieldset>
           </div>
 
+          <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
+
+            <h2 id="is-child" class="form-label-bold">Is this an expense for your child?</h2>
+
+            {% if errors['is-child'][0] %}
+              <span class="error-message">{{ errors['is-child'][0] }}</span>
+            {% endif %}
+
+            <fieldset>
+
+              <label for="is-child-yes" class="block-label inline">
+                <input id="is-child-yes"
+                       type="radio"
+                       name="is-child"
+                       value="yes"
+                       {% if expense['is-child'] == 'yes' %} checked {% endif %}>
+                Yes
+              </label>
+              <label for="is-child-no" class="block-label inline">
+                <input id="is-child-no"
+                       type="radio"
+                       name="is-child"
+                       value="no"
+                       {% if expense['is-child'] == 'no' %} checked {% endif %}>
+                No
+              </label>
+
+            </fieldset>
+          </div>
+
           <div class="form-group {% if errors['cost'][0] %} error {% endif %}">
             <label id="cost" for="cost-input" class="form-label-bold">Cost</label>
 

--- a/app/views/first-time/eligibility/claim/plane-details.html
+++ b/app/views/first-time/eligibility/claim/plane-details.html
@@ -89,7 +89,7 @@
 
           <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
 
-            <h2 id="is-child" class="form-label-bold">Is this an expense for your child?</h2>
+            <h2 id="is-child" class="form-label-bold">Is this a child ticket?</h2>
 
             {% if errors['is-child'][0] %}
               <span class="error-message">{{ errors['is-child'][0] }}</span>

--- a/app/views/first-time/eligibility/claim/plane-details.html
+++ b/app/views/first-time/eligibility/claim/plane-details.html
@@ -57,35 +57,7 @@
 
         <div class="form-group">
 
-          <div class="form-group {% if errors['return-journey'][0] %} error {% endif %}">
-
-            <h2 id="return-journey" class="form-label-bold">Is this a return journey?</h2>
-
-            {% if errors['return-journey'][0] %}
-              <span class="error-message">{{ errors['return-journey'][0] }}</span>
-            {% endif %}
-
-            <fieldset>
-
-              <label for="return-yes" class="block-label inline">
-                <input id="return-yes"
-                       type="radio"
-                       name="return-journey"
-                       value="yes"
-                       {% if expense['return-journey'] == 'yes' %} checked {% endif %}>
-                Yes
-              </label>
-              <label for="return-no" class="block-label inline">
-                <input id="return-no"
-                       type="radio"
-                       name="return-journey"
-                       value="no"
-                       {% if expense['return-journey'] == 'no' %} checked {% endif %}>
-                No
-              </label>
-
-            </fieldset>
-          </div>
+          {% include "partials/expenses/return-journey.html" %}
 
           {% include "partials/expenses/is-child.html" %}
 

--- a/app/views/first-time/eligibility/claim/train-details.html
+++ b/app/views/first-time/eligibility/claim/train-details.html
@@ -85,7 +85,7 @@
 
           <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
 
-            <h2 id="is-child" class="form-label-bold">Is this an expense for your child?</h2>
+            <h2 id="is-child" class="form-label-bold">Is this a child ticket?</h2>
 
             {% if errors['is-child'][0] %}
               <span class="error-message">{{ errors['is-child'][0] }}</span>

--- a/app/views/first-time/eligibility/claim/train-details.html
+++ b/app/views/first-time/eligibility/claim/train-details.html
@@ -53,35 +53,7 @@
 
         <div class="form-group">
 
-          <div class="form-group {% if errors['return-journey'][0] %} error {% endif %}">
-
-            <h2 id="return-journey" class="form-label-bold">Is this a return journey?</h2>
-
-            {% if errors['return-journey'][0] %}
-              <span class="error-message">{{ errors['return-journey'][0] }}</span>
-            {% endif %}
-
-            <fieldset>
-
-              <label for="return-yes" class="block-label inline">
-                <input id="return-yes"
-                       type="radio"
-                       name="return-journey"
-                       value="yes"
-                       {% if expense['return-journey'] == 'yes' %} checked {% endif %}>
-                Yes
-              </label>
-              <label for="return-no" class="block-label inline">
-                <input id="return-no"
-                       type="radio"
-                       name="return-journey"
-                       value="no"
-                       {% if expense['return-journey'] == 'no' %} checked {% endif %}>
-                No
-              </label>
-
-            </fieldset>
-          </div>
+          {% include "partials/expenses/return-journey.html" %}
 
           {% include "partials/expenses/is-child.html" %}
 

--- a/app/views/first-time/eligibility/claim/train-details.html
+++ b/app/views/first-time/eligibility/claim/train-details.html
@@ -83,6 +83,36 @@
             </fieldset>
           </div>
 
+          <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
+
+            <h2 id="is-child" class="form-label-bold">Is this an expense for your child?</h2>
+
+            {% if errors['is-child'][0] %}
+              <span class="error-message">{{ errors['is-child'][0] }}</span>
+            {% endif %}
+
+            <fieldset>
+
+              <label for="is-child-yes" class="block-label inline">
+                <input id="is-child-yes"
+                       type="radio"
+                       name="is-child"
+                       value="yes"
+                       {% if expense['is-child'] == 'yes' %} checked {% endif %}>
+                Yes
+              </label>
+              <label for="is-child-no" class="block-label inline">
+                <input id="is-child-no"
+                       type="radio"
+                       name="is-child"
+                       value="no"
+                       {% if expense['is-child'] == 'no' %} checked {% endif %}>
+                No
+              </label>
+
+            </fieldset>
+          </div>
+
           <div class="form-group {% if errors['cost'][0] %} error {% endif %}">
             <label id="cost" for="cost-input" class="form-label-bold">Cost</label>
 

--- a/app/views/first-time/eligibility/claim/train-details.html
+++ b/app/views/first-time/eligibility/claim/train-details.html
@@ -83,35 +83,7 @@
             </fieldset>
           </div>
 
-          <div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
-
-            <h2 id="is-child" class="form-label-bold">Is this a child ticket?</h2>
-
-            {% if errors['is-child'][0] %}
-              <span class="error-message">{{ errors['is-child'][0] }}</span>
-            {% endif %}
-
-            <fieldset>
-
-              <label for="is-child-yes" class="block-label inline">
-                <input id="is-child-yes"
-                       type="radio"
-                       name="is-child"
-                       value="yes"
-                       {% if expense['is-child'] == 'yes' %} checked {% endif %}>
-                Yes
-              </label>
-              <label for="is-child-no" class="block-label inline">
-                <input id="is-child-no"
-                       type="radio"
-                       name="is-child"
-                       value="no"
-                       {% if expense['is-child'] == 'no' %} checked {% endif %}>
-                No
-              </label>
-
-            </fieldset>
-          </div>
+          {% include "partials/expenses/is-child.html" %}
 
           <div class="form-group {% if errors['cost'][0] %} error {% endif %}">
             <label id="cost" for="cost-input" class="form-label-bold">Cost</label>

--- a/app/views/partials/expenses/is-child.html
+++ b/app/views/partials/expenses/is-child.html
@@ -3,7 +3,7 @@
   <h2 id="is-child" class="form-label-bold">Is this a child ticket?</h2>
 
   {% if errors['is-child'][0] %}
-  <span class="error-message">{{ errors['is-child'][0] }}</span>
+    <span class="error-message">{{ errors['is-child'][0] }}</span>
   {% endif %}
 
   <fieldset>

--- a/app/views/partials/expenses/is-child.html
+++ b/app/views/partials/expenses/is-child.html
@@ -1,0 +1,29 @@
+<div class="form-group {% if errors['is-child'][0] %} error {% endif %}">
+
+  <h2 id="is-child" class="form-label-bold">Is this a child ticket?</h2>
+
+  {% if errors['is-child'][0] %}
+  <span class="error-message">{{ errors['is-child'][0] }}</span>
+  {% endif %}
+
+  <fieldset>
+
+    <label for="is-child-yes" class="block-label inline">
+      <input id="is-child-yes"
+             type="radio"
+             name="is-child"
+             value="yes"
+             {% if expense['is-child'] == 'yes' %} checked {% endif %}>
+      Yes
+    </label>
+    <label for="is-child-no" class="block-label inline">
+      <input id="is-child-no"
+             type="radio"
+             name="is-child"
+             value="no"
+             {% if expense['is-child'] == 'no' %} checked {% endif %}>
+      No
+    </label>
+
+  </fieldset>
+</div>

--- a/app/views/partials/expenses/return-journey.html
+++ b/app/views/partials/expenses/return-journey.html
@@ -5,7 +5,7 @@
     <h2 id="return-journey" class="form-label-bold">Is this a return journey?</h2>
 
     {% if errors['return-journey'][0] %}
-    <span class="error-message">{{ errors['return-journey'][0] }}</span>
+      <span class="error-message">{{ errors['return-journey'][0] }}</span>
     {% endif %}
 
     <fieldset>

--- a/app/views/partials/expenses/return-journey.html
+++ b/app/views/partials/expenses/return-journey.html
@@ -1,0 +1,31 @@
+<div class="form-group">
+
+  <div class="form-group {% if errors['return-journey'][0] %} error {% endif %}">
+
+    <h2 id="return-journey" class="form-label-bold">Is this a return journey?</h2>
+
+    {% if errors['return-journey'][0] %}
+    <span class="error-message">{{ errors['return-journey'][0] }}</span>
+    {% endif %}
+
+    <fieldset>
+
+      <label for="return-yes" class="block-label inline">
+        <input id="return-yes"
+               type="radio"
+               name="return-journey"
+               value="yes"
+               {% if expense['return-journey'] == 'yes' %} checked {% endif %}>
+        Yes
+      </label>
+      <label for="return-no" class="block-label inline">
+        <input id="return-no"
+               type="radio"
+               name="return-journey"
+               value="no"
+               {% if expense['return-journey'] == 'no' %} checked {% endif %}>
+        No
+      </label>
+
+    </fieldset>
+  </div>

--- a/test/e2e/spec.js
+++ b/test/e2e/spec.js
@@ -80,11 +80,12 @@ describe('First time claim flow', () => {
       .waitForExist('#car-details-submit')
       .click('#car-details-submit')
 
-      // Bus #1
+      // Bus #1 (adult expense)
       .waitForExist('#bus-details-submit')
       .setValue('#from-input', 'Euston')
       .setValue('#to-input', 'Birmingham New Street')
       .click('#return-no')
+      .click('#is-child-no')
       .setValue('#cost-input', '20')
       .click('#add-another-journey')
       .click('#bus-details-submit')
@@ -92,11 +93,12 @@ describe('First time claim flow', () => {
       // Allow second bus page to load
       .pause(3000)
 
-      // Bus #2 (add another journey)
+      // Bus #2 (add another journey) (child expense)
       .waitForExist('#bus-details-submit')
       .setValue('#from-input', 'Birmingham New Street')
       .setValue('#to-input', 'Euston')
       .click('#return-no')
+      .click('#is-child-yes')
       .setValue('#cost-input', '20')
       .click('#bus-details-submit')
 

--- a/test/helpers/data/expense-helper.js
+++ b/test/helpers/data/expense-helper.js
@@ -11,6 +11,7 @@ module.exports.TO = 'Edinburgh'
 module.exports.IS_RETURN = 'yes'
 module.exports.DURATION_OF_TRAVEL = null
 module.exports.TICKET_TYPE = null
+module.exports.IS_CHILD = 'yes'
 
 module.exports.build = function (claimId) {
   return new BusExpense(
@@ -18,7 +19,8 @@ module.exports.build = function (claimId) {
     this.COST,
     this.FROM,
     this.TO,
-    this.IS_RETURN
+    this.IS_RETURN,
+    this.IS_CHILD
   )
 }
 

--- a/test/integration/services/data/test-insert-expense.js
+++ b/test/integration/services/data/test-insert-expense.js
@@ -33,6 +33,7 @@ describe('services/data/insert-expense', function () {
         expect(expense.IsReturn).to.equal(expenseHelper.IS_RETURN === 'yes')
         expect(expense.DurationOfTravel).to.equal(expenseHelper.DURATION_OF_TRAVEL)
         expect(expense.TicketType).to.equal(expenseHelper.TICKET_TYPE)
+        expect(expense.IsChild).to.equal(expenseHelper.IS_CHILD === 'yes')
       })
   })
 

--- a/test/unit/services/domain/expenses/test-bus-expense.js
+++ b/test/unit/services/domain/expenses/test-bus-expense.js
@@ -8,6 +8,7 @@ describe('services/domain/expenses/bus-expense', function () {
   const VALID_FROM = 'some from'
   const VALID_TO = 'some to'
   const VALID_IS_RETURN = 'yes'
+  const VALID_IS_CHILD = 'yes'
   const INVALID_COST = '0'
 
   it('should construct a domain object given valid input', function () {
@@ -16,13 +17,15 @@ describe('services/domain/expenses/bus-expense', function () {
       VALID_COST,
       VALID_FROM,
       VALID_TO,
-      VALID_IS_RETURN
+      VALID_IS_RETURN,
+      VALID_IS_CHILD
     )
     expect(expense.claimId).to.equal(VALID_CLAIM_ID)
     expect(expense.cost).to.equal(VALID_COST)
     expect(expense.from).to.equal(VALID_FROM)
     expect(expense.to).to.equal(VALID_TO)
     expect(expense.isReturn).to.equal(VALID_IS_RETURN)
+    expect(expense.isChild).to.equal(VALID_IS_CHILD)
   })
 
   it('should throw an error if passed invalid data', function () {
@@ -32,7 +35,8 @@ describe('services/domain/expenses/bus-expense', function () {
         INVALID_COST,
         VALID_FROM,
         VALID_TO,
-        VALID_IS_RETURN
+        VALID_IS_RETURN,
+        VALID_IS_CHILD
       ).isValid()
     }).to.throw(ValidationError)
   })

--- a/test/unit/services/domain/expenses/test-ferry-expense.js
+++ b/test/unit/services/domain/expenses/test-ferry-expense.js
@@ -9,6 +9,7 @@ describe('services/domain/expenses/ferry-expense', function () {
   const VALID_TO = 'some to'
   const VALID_IS_RETURN = 'yes'
   const VALID_TICKET_TYPE = 'car passenger'
+  const VALID_IS_CHILD = 'yes'
   const INVALID_COST = '0'
 
   it('should construct a domain object given valid input', function () {
@@ -18,7 +19,8 @@ describe('services/domain/expenses/ferry-expense', function () {
       VALID_FROM,
       VALID_TO,
       VALID_IS_RETURN,
-      VALID_TICKET_TYPE
+      VALID_TICKET_TYPE,
+      VALID_IS_CHILD
     )
     expect(expense.claimId).to.equal(VALID_CLAIM_ID)
     expect(expense.cost).to.equal(VALID_COST)
@@ -26,6 +28,7 @@ describe('services/domain/expenses/ferry-expense', function () {
     expect(expense.to).to.equal(VALID_TO)
     expect(expense.isReturn).to.equal(VALID_IS_RETURN)
     expect(expense.ticketType).to.equal(VALID_TICKET_TYPE)
+    expect(expense.isChild).to.equal(VALID_IS_CHILD)
   })
 
   it('should throw an error if passed invalid data', function () {
@@ -36,7 +39,8 @@ describe('services/domain/expenses/ferry-expense', function () {
         VALID_FROM,
         VALID_TO,
         VALID_IS_RETURN,
-        VALID_TICKET_TYPE
+        VALID_TICKET_TYPE,
+        VALID_IS_CHILD
       ).isValid()
     }).to.throw(ValidationError)
   })

--- a/test/unit/services/domain/expenses/test-plane-expense.js
+++ b/test/unit/services/domain/expenses/test-plane-expense.js
@@ -8,6 +8,7 @@ describe('services/domain/expenses/plane-expense', function () {
   const VALID_FROM = 'some from'
   const VALID_TO = 'some to'
   const VALID_IS_RETURN = 'yes'
+  const VALID_IS_CHILD = 'yes'
   const INVALID_COST = '0'
 
   it('should construct a domain object given valid input', function () {
@@ -16,13 +17,15 @@ describe('services/domain/expenses/plane-expense', function () {
       VALID_COST,
       VALID_FROM,
       VALID_TO,
-      VALID_IS_RETURN
+      VALID_IS_RETURN,
+      VALID_IS_CHILD
     )
     expect(expense.claimId).to.equal(VALID_CLAIM_ID)
     expect(expense.cost).to.equal(VALID_COST)
     expect(expense.from).to.equal(VALID_FROM)
     expect(expense.to).to.equal(VALID_TO)
     expect(expense.isReturn).to.equal(VALID_IS_RETURN)
+    expect(expense.isChild).to.equal(VALID_IS_CHILD)
   })
 
   it('should throw an error if passed invalid data', function () {
@@ -32,7 +35,8 @@ describe('services/domain/expenses/plane-expense', function () {
         INVALID_COST,
         VALID_FROM,
         VALID_TO,
-        VALID_IS_RETURN
+        VALID_IS_RETURN,
+        VALID_IS_CHILD
       ).isValid()
     }).to.throw(ValidationError)
   })

--- a/test/unit/services/domain/expenses/test-train-expense.js
+++ b/test/unit/services/domain/expenses/test-train-expense.js
@@ -8,6 +8,7 @@ describe('services/domain/expenses/train-expense', function () {
   const VALID_FROM = 'some from'
   const VALID_TO = 'some to'
   const VALID_IS_RETURN = 'yes'
+  const VALID_IS_CHILD = 'yes'
   const INVALID_COST = '0'
 
   it('should construct a domain object given valid input', function () {
@@ -16,13 +17,15 @@ describe('services/domain/expenses/train-expense', function () {
       VALID_COST,
       VALID_FROM,
       VALID_TO,
-      VALID_IS_RETURN
+      VALID_IS_RETURN,
+      VALID_IS_CHILD
     )
     expect(expense.claimId).to.equal(VALID_CLAIM_ID)
     expect(expense.cost).to.equal(VALID_COST)
     expect(expense.from).to.equal(VALID_FROM)
     expect(expense.to).to.equal(VALID_TO)
     expect(expense.isReturn).to.equal(VALID_IS_RETURN)
+    expect(expense.isChild).to.equal(VALID_IS_CHILD)
   })
 
   it('should throw an error if passed invalid data', function () {
@@ -32,7 +35,8 @@ describe('services/domain/expenses/train-expense', function () {
         INVALID_COST,
         VALID_FROM,
         VALID_TO,
-        VALID_IS_RETURN
+        VALID_IS_RETURN,
+        VALID_IS_CHILD
       ).isValid()
     }).to.throw(ValidationError)
   })


### PR DESCRIPTION
Added the ability to mark an expense as a child expenses on the bus, ferry, plane, and train expense pages.
- Updated HTML to include a radio selection for isChild + elements required for validation.
- Updated the route to pass the isChild value to the domain objects constructor. 
- Updated the BaseExpense domain object to set the isChild value.
- Updated the bus, ferry, plane, and train expense domain objects to pass isChild value to the BaseExpense constructor and to validate the isChild value.
- Updated all other Expense types to pass a null value for isChild to the BaseExpense constructor.
- Updated the expense-helper to include isChild.
- Updated all affected unit tests.
- Updated the end-to-end test to handle the inclusion of the new radio selection.
- Renamed ExpenseBase to BaseExpense.

## Checklist

- [x] Unit tests
- [x] End-to-End tests
- [ ] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated