### PR TITLE
Feature/apvs 349/update claim summary to display child expenses and child details

### DIFF
--- a/app/services/data/get-claim-summary.js
+++ b/app/services/data/get-claim-summary.js
@@ -39,7 +39,8 @@ module.exports = function (claimId) {
               'ClaimExpense.IsReturn',
               'ClaimExpense.TravelTime',
               'ClaimExpense.DurationOfTravel',
-              'ClaimExpense.TicketType'
+              'ClaimExpense.TicketType',
+              'ClaimExpense.IsChild'
             )
             .orderBy('ClaimExpense.ClaimExpenseId')
             .then(function (claimExpenses) {

--- a/app/services/data/get-claim-summary.js
+++ b/app/services/data/get-claim-summary.js
@@ -2,26 +2,46 @@ const config = require('../../../knexfile').extweb
 const knex = require('knex')(config)
 const documentTypeEnum = require('../../constants/document-type-enum')
 
+// TODO: Need to add ability to retrieve claimChild table contents.
 module.exports = function (claimId) {
   return knex('Claim')
     .join('Eligibility', 'Claim.Reference', '=', 'Eligibility.Reference')
     .join('Visitor', 'Eligibility.Reference', '=', 'Visitor.Reference')
     .join('Prisoner', 'Eligibility.Reference', '=', 'Prisoner.Reference')
     .where('Claim.ClaimId', claimId)
-    .first('Eligibility.Reference', 'Claim.DateSubmitted', 'Claim.DateOfJourney', 'Visitor.FirstName', 'Visitor.LastName', 'Visitor.Benefit',
-      'Prisoner.FirstName AS PrisonerFirstName', 'Prisoner.LastName AS PrisonerLastName',
-      'Prisoner.DateOfBirth AS PrisonerDateOfBirth', 'Prisoner.PrisonNumber', 'Prisoner.NameOfPrison')
+    .first(
+      'Eligibility.Reference',
+      'Claim.DateSubmitted',
+      'Claim.DateOfJourney',
+      'Visitor.FirstName',
+      'Visitor.LastName',
+      'Visitor.Benefit',
+      'Prisoner.FirstName AS PrisonerFirstName',
+      'Prisoner.LastName AS PrisonerLastName',
+      'Prisoner.DateOfBirth AS PrisonerDateOfBirth',
+      'Prisoner.PrisonNumber',
+      'Prisoner.NameOfPrison'
+    )
     .then(function (claim) {
       return knex('ClaimDocument')
         .join('Claim', 'ClaimDocument.ClaimId', '=', 'Claim.ClaimId')
-        .where({'ClaimDocument.DocumentType': documentTypeEnum.VISIT_CONFIRMATION, 'Claim.ClaimId': claimId})
+        .where({ 'ClaimDocument.DocumentType': documentTypeEnum.VISIT_CONFIRMATION, 'Claim.ClaimId': claimId} )
         .first('ClaimDocument.DocumentStatus', 'ClaimDocument.DocumentType')
         .then(function (visitConfirmationDocumentStatus) {
           return knex('Claim')
             .join('ClaimExpense', 'Claim.ClaimId', '=', 'ClaimExpense.ClaimId')
-            .where({'Claim.ClaimId': claimId, 'ClaimExpense.IsEnabled': true})
-            .select('ClaimExpense.ClaimExpenseId', 'ClaimExpense.ExpenseType', 'ClaimExpense.Cost', 'ClaimExpense.To', 'ClaimExpense.From', 'ClaimExpense.IsReturn', 'ClaimExpense.TravelTime',
-              'ClaimExpense.DurationOfTravel', 'ClaimExpense.TicketType')
+            .where({ 'Claim.ClaimId': claimId, 'ClaimExpense.IsEnabled': true })
+            .select(
+              'ClaimExpense.ClaimExpenseId',
+              'ClaimExpense.ExpenseType',
+              'ClaimExpense.Cost',
+              'ClaimExpense.To',
+              'ClaimExpense.From',
+              'ClaimExpense.IsReturn',
+              'ClaimExpense.TravelTime',
+              'ClaimExpense.DurationOfTravel',
+              'ClaimExpense.TicketType'
+            )
             .orderBy('ClaimExpense.ClaimExpenseId')
             .then(function (claimExpenses) {
               claimExpenses.forEach(function (expense) {

--- a/app/views/first-time/eligibility/claim/claim-summary.html
+++ b/app/views/first-time/eligibility/claim/claim-summary.html
@@ -22,9 +22,7 @@
       <td>{{ claimDetails.claim['FirstName'] }} {{ claimDetails.claim['LastName'] }}</td>
     </tr>
 
-    <!-- TODO: Replace with iteration over real values retrieved from the database. -->
-    {% set claimChild = [{ Name: "Example Child 1" }, { Name: "Example Chile 2" }] %}
-    {% for child in claimChild %}
+    {% for child in claimDetails.claimChild %}
     <tr>
       <td>Child</td>
       <td>{{ child['Name'] }}</td>

--- a/app/views/first-time/eligibility/claim/claim-summary.html
+++ b/app/views/first-time/eligibility/claim/claim-summary.html
@@ -22,6 +22,15 @@
       <td>{{ claimDetails.claim['FirstName'] }} {{ claimDetails.claim['LastName'] }}</td>
     </tr>
 
+    <!-- TODO: Replace with iteration over real values retrieved from the database. -->
+    {% set claimChild = [{ Name: "Example Child 1" }, { Name: "Example Chile 2" }] %}
+    {% for child in claimChild %}
+    <tr>
+      <td>Child</td>
+      <td>{{ child['Name'] }}</td>
+    </tr>
+    {% endfor %}
+
     <tr>
       <td>Benefit information</td>
       <td>

--- a/app/views/helpers/claim-expense-helper.js
+++ b/app/views/helpers/claim-expense-helper.js
@@ -12,12 +12,9 @@ module.exports.FormattedDetail = function (expense) {
       formattedDetail = `${expense.From} to ${expense.To} for ${expense.DurationOfTravel} days`
       break
     case 'bus':
+    case 'plane':
     case 'train':
-      if (expense.IsReturn) {
-        formattedDetail = `${expense.From} to ${expense.To} - Return`
-      } else {
-        formattedDetail = `${expense.From} to ${expense.To}`
-      }
+      formattedDetail = `${addChildPrefix(expense)}${expense.From} to ${expense.To}${addReturnPostfix(expense)}`
       break
     case 'light refreshment':
       if (expense.TravelTime === 'over-five') {
@@ -30,11 +27,27 @@ module.exports.FormattedDetail = function (expense) {
       formattedDetail = `Nights stayed: ${expense.DurationOfTravel}`
       break
     case 'ferry':
-      formattedDetail = `${expense.From} to ${expense.To} as ${displayFieldNames[expense.TicketType]}`
+      formattedDetail = `${addChildPrefix(expense)}${expense.From} to ${expense.To} as ${displayFieldNames[expense.TicketType]}${addReturnPostfix(expense)}`
       break
     default:
       formattedDetail = `${expense.From} to ${expense.To}`
   }
 
   return formattedDetail
+}
+
+function addChildPrefix (expense) {
+  if (expense.IsChild) {
+    return 'Child - '
+  } else {
+    return ''
+  }
+}
+
+function addReturnPostfix (expense) {
+  if (expense.IsReturn) {
+    return ' - Return'
+  } else {
+    return ''
+  }
 }

--- a/test/integration/services/data/test-get-claim-summary.js
+++ b/test/integration/services/data/test-get-claim-summary.js
@@ -1,6 +1,7 @@
 const expect = require('chai').expect
 const eligiblityHelper = require('../../../helpers/data/eligibility-helper')
 const claimHelper = require('../../../helpers/data/claim-helper')
+const claimChildHelper = require('../../../helpers/data/claim-child-helper')
 const expenseHelper = require('../../../helpers/data/expense-helper')
 const claimDocumentHelper = require('../../../helpers/data/claim-document-helper')
 
@@ -19,6 +20,9 @@ describe('services/data/get-claim-summary', function () {
             return expenseHelper.insert(claimId)
           })
           .then(function () {
+            return claimChildHelper.insert(claimId)
+          })
+          .then(function () {
             return claimDocumentHelper.insertPrisonConfirmation(claimId)
           })
       })
@@ -35,11 +39,15 @@ describe('services/data/get-claim-summary', function () {
         expect(result.claim.visitConfirmation.DocumentStatus).to.equal(claimDocumentHelper.DOCUMENT_STATUS)
         expect(result.claimExpenses[0].ExpenseType).to.equal(expenseHelper.EXPENSE_TYPE)
         expect(result.claimExpenses[0].Cost).to.equal(Number(expenseHelper.COST).toFixed(2))
+        expect(result.claimChild[0].Name).to.equal(claimChildHelper.CHILD_NAME)
       })
   })
 
   after(function () {
     return expenseHelper.delete(claimId)
+      .then(function () {
+        return claimChildHelper.delete(claimId)
+      })
       .then(function () {
         return claimDocumentHelper.delete(claimId)
       })

--- a/test/unit/views/helpers/test-claim-expense-helper.js
+++ b/test/unit/views/helpers/test-claim-expense-helper.js
@@ -10,34 +10,66 @@ describe('views/helpers/claim-expense-helper', function () {
   })
 
   describe('FormattedDetail', function () {
+    const FROM = 'PointA'
+    const TO = 'PointB'
+    const DURATION_OF_TRAVBL = 2
+    const TICKET_TYPE = 'foot-passenger'
+
+    const CHILD_PREFIX = 'Child - '
+    const RETURN_PREFIX = ' - Return'
+
     it('should return formatted detail string for ClaimExpense', function () {
-      const from = 'PointA'
-      const to = 'PointB'
-      const durationOfTravel = 2
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'car hire', From: FROM, To: TO, DurationOfTravel: 2 }))
+        .to.equal(`${FROM} to ${TO} for ${DURATION_OF_TRAVBL} days`)
 
-      expect(claimExpenseHelper.FormattedDetail({ExpenseType: 'car hire', From: from, To: to, DurationOfTravel: 2})).to.equal(
-        `${from} to ${to} for ${durationOfTravel} days`)
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'bus', From: FROM, To: TO }))
+        .to.equal(`${FROM} to ${TO}`)
 
-      expect(claimExpenseHelper.FormattedDetail({ExpenseType: 'bus', From: from, To: to})).to.equal(
-        `${from} to ${to}`)
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'train', From: FROM, To: TO }))
+        .to.equal(`${FROM} to ${TO}`)
 
-      expect(claimExpenseHelper.FormattedDetail({ExpenseType: 'train', From: from, To: to, IsReturn: true})).to.equal(
-        `${from} to ${to} - Return`)
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'light refreshment', TravelTime: 'over-five' }))
+        .to.equal('Over five hours away but under ten hours')
 
-      expect(claimExpenseHelper.FormattedDetail({ExpenseType: 'light refreshment', TravelTime: 'over-five'})).to.equal(
-        'Over five hours away but under ten hours')
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'light refreshment', TravelTime: 'over-ten' }))
+        .to.equal('Over ten hours away')
 
-      expect(claimExpenseHelper.FormattedDetail({ExpenseType: 'light refreshment', TravelTime: 'over-ten'})).to.equal(
-        'Over ten hours away')
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'accommodation', DurationOfTravel: DURATION_OF_TRAVBL }))
+        .to.equal(`Nights stayed: ${DURATION_OF_TRAVBL}`)
 
-      expect(claimExpenseHelper.FormattedDetail({ExpenseType: 'accommodation', DurationOfTravel: durationOfTravel})).to.equal(
-        `Nights stayed: ${durationOfTravel}`)
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'ferry', From: FROM, To: TO, TicketType: TICKET_TYPE }))
+        .to.equal(`${FROM} to ${TO} as a foot passenger`)
 
-      expect(claimExpenseHelper.FormattedDetail({ExpenseType: 'ferry', From: from, To: to, TicketType: 'foot-passenger'})).to.equal(
-        `${from} to ${to} as a foot passenger`)
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'anything-else', From: FROM, To: TO }))
+        .to.equal(`${FROM} to ${TO}`)
+    })
 
-      expect(claimExpenseHelper.FormattedDetail({ExpenseType: 'anything-else', From: from, To: to})).to.equal(
-        `${from} to ${to}`)
+    it('should prepand child prefix for bus, train, plane, and ferry expenses', function () {
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'bus', From: FROM, To: TO, IsChild: true }))
+        .to.equal(`${CHILD_PREFIX}${FROM} to ${TO}`)
+
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'train', From: FROM, To: TO, IsChild: true }))
+        .to.equal(`${CHILD_PREFIX}${FROM} to ${TO}`)
+
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'plane', From: FROM, To: TO, IsChild: true }))
+        .to.equal(`${CHILD_PREFIX}${FROM} to ${TO}`)
+
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'ferry', From: FROM, To: TO, IsChild: true, TicketType: TICKET_TYPE }))
+        .to.equal(`${CHILD_PREFIX}${FROM} to ${TO} as a foot passenger`)
+    })
+
+    it('should append return postfix for bus, train, plane, and ferry expenses', function () {
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'bus', From: FROM, To: TO, IsReturn: true }))
+        .to.equal(`${FROM} to ${TO}${RETURN_PREFIX}`)
+
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'train', From: FROM, To: TO, IsReturn: true }))
+        .to.equal(`${FROM} to ${TO}${RETURN_PREFIX}`)
+
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'plane', From: FROM, To: TO, IsReturn: true }))
+        .to.equal(`${FROM} to ${TO}${RETURN_PREFIX}`)
+
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'ferry', From: FROM, To: TO, IsReturn: true, TicketType: TICKET_TYPE }))
+        .to.equal(`${FROM} to ${TO} as a foot passenger${RETURN_PREFIX}`)
     })
   })
 })

--- a/test/unit/views/helpers/test-claim-expense-helper.js
+++ b/test/unit/views/helpers/test-claim-expense-helper.js
@@ -12,7 +12,7 @@ describe('views/helpers/claim-expense-helper', function () {
   describe('FormattedDetail', function () {
     const FROM = 'PointA'
     const TO = 'PointB'
-    const DURATION_OF_TRAVAL = 2
+    const DURATION_OF_TRAVEL = '2'
     const TICKET_TYPE = 'foot-passenger'
 
     const CHILD_PREFIX = 'Child - '
@@ -20,7 +20,7 @@ describe('views/helpers/claim-expense-helper', function () {
 
     it('should return formatted detail string for ClaimExpense', function () {
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'car hire', From: FROM, To: TO, DurationOfTravel: 2 }))
-        .to.equal(`${FROM} to ${TO} for ${DURATION_OF_TRAVAL} days`)
+        .to.equal(`${FROM} to ${TO} for ${DURATION_OF_TRAVEL} days`)
 
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'bus', From: FROM, To: TO }))
         .to.equal(`${FROM} to ${TO}`)
@@ -34,8 +34,8 @@ describe('views/helpers/claim-expense-helper', function () {
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'light refreshment', TravelTime: 'over-ten' }))
         .to.equal('Over ten hours away')
 
-      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'accommodation', DurationOfTravel: DURATION_OF_TRAVAL }))
-        .to.equal(`Nights stayed: ${DURATION_OF_TRAVAL}`)
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'accommodation', DurationOfTravel: DURATION_OF_TRAVEL }))
+        .to.equal(`Nights stayed: ${DURATION_OF_TRAVEL}`)
 
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'ferry', From: FROM, To: TO, TicketType: TICKET_TYPE }))
         .to.equal(`${FROM} to ${TO} as a foot passenger`)

--- a/test/unit/views/helpers/test-claim-expense-helper.js
+++ b/test/unit/views/helpers/test-claim-expense-helper.js
@@ -12,15 +12,15 @@ describe('views/helpers/claim-expense-helper', function () {
   describe('FormattedDetail', function () {
     const FROM = 'PointA'
     const TO = 'PointB'
-    const DURATION_OF_TRAVBL = 2
+    const DURATION_OF_TRAVAL = 2
     const TICKET_TYPE = 'foot-passenger'
 
     const CHILD_PREFIX = 'Child - '
-    const RETURN_PREFIX = ' - Return'
+    const RETURN_POSTFIX = ' - Return'
 
     it('should return formatted detail string for ClaimExpense', function () {
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'car hire', From: FROM, To: TO, DurationOfTravel: 2 }))
-        .to.equal(`${FROM} to ${TO} for ${DURATION_OF_TRAVBL} days`)
+        .to.equal(`${FROM} to ${TO} for ${DURATION_OF_TRAVAL} days`)
 
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'bus', From: FROM, To: TO }))
         .to.equal(`${FROM} to ${TO}`)
@@ -34,8 +34,8 @@ describe('views/helpers/claim-expense-helper', function () {
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'light refreshment', TravelTime: 'over-ten' }))
         .to.equal('Over ten hours away')
 
-      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'accommodation', DurationOfTravel: DURATION_OF_TRAVBL }))
-        .to.equal(`Nights stayed: ${DURATION_OF_TRAVBL}`)
+      expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'accommodation', DurationOfTravel: DURATION_OF_TRAVAL }))
+        .to.equal(`Nights stayed: ${DURATION_OF_TRAVAL}`)
 
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'ferry', From: FROM, To: TO, TicketType: TICKET_TYPE }))
         .to.equal(`${FROM} to ${TO} as a foot passenger`)
@@ -44,7 +44,7 @@ describe('views/helpers/claim-expense-helper', function () {
         .to.equal(`${FROM} to ${TO}`)
     })
 
-    it('should prepand child prefix for bus, train, plane, and ferry expenses', function () {
+    it('should prepend child prefix for bus, train, plane, and ferry expenses', function () {
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'bus', From: FROM, To: TO, IsChild: true }))
         .to.equal(`${CHILD_PREFIX}${FROM} to ${TO}`)
 
@@ -60,16 +60,16 @@ describe('views/helpers/claim-expense-helper', function () {
 
     it('should append return postfix for bus, train, plane, and ferry expenses', function () {
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'bus', From: FROM, To: TO, IsReturn: true }))
-        .to.equal(`${FROM} to ${TO}${RETURN_PREFIX}`)
+        .to.equal(`${FROM} to ${TO}${RETURN_POSTFIX}`)
 
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'train', From: FROM, To: TO, IsReturn: true }))
-        .to.equal(`${FROM} to ${TO}${RETURN_PREFIX}`)
+        .to.equal(`${FROM} to ${TO}${RETURN_POSTFIX}`)
 
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'plane', From: FROM, To: TO, IsReturn: true }))
-        .to.equal(`${FROM} to ${TO}${RETURN_PREFIX}`)
+        .to.equal(`${FROM} to ${TO}${RETURN_POSTFIX}`)
 
       expect(claimExpenseHelper.FormattedDetail({ ExpenseType: 'ferry', From: FROM, To: TO, IsReturn: true, TicketType: TICKET_TYPE }))
-        .to.equal(`${FROM} to ${TO} as a foot passenger${RETURN_PREFIX}`)
+        .to.equal(`${FROM} to ${TO} as a foot passenger${RETURN_POSTFIX}`)
     })
   })
 })


### PR DESCRIPTION
Updated the claim summary page.
- Now displays the name of each of the children the claimant entered.
- Indicates any child expenses with a the 'Child - ' prefix.
- Updated all relevant unit and integration tests.

## Checklist

- [x] Unit tests
- [ ] End-to-End tests
- [x] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
