### PR TITLE
Fixed journey-information form repopulation on validation fail 

### DIFF
--- a/app/views/first-time/eligibility/new-claim/journey-information.html
+++ b/app/views/first-time/eligibility/new-claim/journey-information.html
@@ -76,7 +76,7 @@
                      type="radio"
                      name="child-visitor"
                      value="yes"
-                     {% if expense['child-visitor'] == 'yes' %} checked {% endif %}>
+                     {% if claim['child-visitor'] == 'yes' %} checked {% endif %}>
               Yes
             </label>
             <label for="child-no" class="block-label inline">
@@ -84,7 +84,7 @@
                      type="radio"
                      name="child-visitor"
                      value="no"
-                     {% if expense['child-visitor'] == 'no' %} checked {% endif %}>
+                     {% if claim['child-visitor'] == 'no' %} checked {% endif %}>
               No
             </label>
 


### PR DESCRIPTION
The child selection on journey-information was not being repopulated on the form. Fixed this.

Closes #159. 

## Checklist

- [ ] Unit tests
- [ ] End-to-End tests
- [ ] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated