### PR TITLE
date-of-birth now handles non-validation errors.

### DIFF
--- a/app/routes/apply/new-eligibility/date-of-birth.js
+++ b/app/routes/apply/new-eligibility/date-of-birth.js
@@ -31,6 +31,8 @@ module.exports = function (router) {
           claimType: req.params.claimType,
           claimant: req.body
         })
+      } else {
+        throw error
       }
     }
   })

--- a/test/unit/routes/first-time/new-eligibility/test-date-of-birth.js
+++ b/test/unit/routes/first-time/new-eligibility/test-date-of-birth.js
@@ -63,14 +63,18 @@ describe('routes/apply/new-eligibility/date-of-birth', function () {
           .expect('location', `/apply/first-time/new-eligibility/${dob}`)
       })
 
-      it('should respond with a 400 for invalid data', function () {
-        stubDateOfBirth.throws(new ValidationError({ 'dob': {} }))
+      it('should respond with a 400 for a validation error', function () {
+        stubDateOfBirth.throws(new ValidationError())
         return supertest(app)
           .post(ROUTE)
           .expect(400)
-          .expect(function () {
-            sinon.assert.calledOnce(stubDateOfBirth)
-          })
+      })
+
+      it('should respond with a 500 for a non-validation error', function () {
+        stubDateOfBirth.throws(new Error())
+        return supertest(app)
+          .post(ROUTE)
+          .expect(500)
       })
     })
 


### PR DESCRIPTION
date-of-birth now handles non-validation errors. 
- Added unit test for else branch in the catch.

## Checklist

- [x] Unit tests
- [ ] End-to-End tests
- [x] Code coverage checked
- [x] Coding standards
- [x] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated