### PR TITLE
Eligibility Fail page now uses the route helper.

### DIFF
--- a/test/unit/routes/test-eligibility-fail.js
+++ b/test/unit/routes/test-eligibility-fail.js
@@ -1,30 +1,21 @@
-var supertest = require('supertest')
-var expect = require('chai').expect
-var express = require('express')
-var mockViewEngine = require('./mock-view-engine')
-var route = require('../../../app/routes/eligibility-fail')
+const routeHelper = require('../../helpers/routes/route-helper')
+const supertest = require('supertest')
+const route = require('../../../app/routes/eligibility-fail')
 
 describe('routes/eligibility-fail', function () {
-  var request
+  const ROUTE = '/eligibility-fail'
+
+  var app
 
   beforeEach(function () {
-    var app = express()
-
-    mockViewEngine(app, '../../../app/views')
-
-    route(app)
-
-    request = supertest(app)
+    app = routeHelper.buildApp(route)
   })
 
-  describe('GET /eligibility-fail', function () {
-    it('should respond with a 200', function (done) {
-      request
-        .get('/eligibility-fail')
-        .expect(200, function (error) {
-          expect(error).to.be.null
-          done()
-        })
+  describe(`GET ${ROUTE}`, function () {
+    it('should respond with a 200', function () {
+      return supertest(app)
+        .get(ROUTE)
+        .expect(200)
     })
   })
 })


### PR DESCRIPTION
Now uses the route helper.
No need for proxy require or sinon here as there is nothing to stub.

Works towards issue #125.

## Checklist

- [x] Unit tests
- [ ] End-to-End tests
- [x] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated

No need for proxy require or sinon here as there is nothing to stub.