### PR TITLE
chore - fix firefox e2e test

### DIFF
--- a/test/e2e/first-time-claim.js
+++ b/test/e2e/first-time-claim.js
@@ -40,6 +40,7 @@ describe('First Time Claim Flow', () => {
       .setValue('#dob-year', '1955')
       .setValue('#prisoner-number', 'A1234BC')
       .setValue('#prison-name-text-input', 'Hewell')
+      .click('#NameOfPrison') // click label to remove input focus
       .click('#about-the-prisoner-submit')
 
       // About you


### PR DESCRIPTION
Added click after setting autocomplete input value to ensure focus is cleared and allow the next click on the submit button to work on firefox

## Checklist

- [ ] Unit tests
- [x] End-to-End tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated

