### PR TITLE
Chore/limit load tests local

### DIFF
--- a/test/load/scenarios.yaml
+++ b/test/load/scenarios.yaml
@@ -1,8 +1,8 @@
 config:
   target: 'http://localhost:3000'
   phases:
-    - duration: 1
-      arrivalRate: 1
+    - duration: 60
+      arrivalRate: 2
   environments:
     staging:
       target: 'http://localhost:3000'

--- a/test/load/scenarios.yaml
+++ b/test/load/scenarios.yaml
@@ -1,11 +1,15 @@
 config:
   target: 'http://localhost:3000'
   phases:
-    - duration: 60
-      arrivalRate: 2
-    - duration: 120
-      arrivalRate: 2
-      rampTo: 10
+    - duration: 1
+      arrivalRate: 1
+  environments:
+    staging:
+      target: 'http://localhost:3000'
+      phases:
+        - duration: 120
+          arrivalRate: 2
+          rampTo: 10
   processor: './load-test-helper.js'
 
 scenarios:


### PR DESCRIPTION
CHORE: Add environments section to scenarios config which will prevent the ramp up phase being run locally as it is likely to cause issues on OSX.