### PR TITLE
Chore/fix cost not approved view claim

### DIFF
--- a/app/services/data/get-claim-expense-by-id-or-last-approved.js
+++ b/app/services/data/get-claim-expense-by-id-or-last-approved.js
@@ -8,6 +8,9 @@ module.exports = function (reference, eligibiltyId, claimId) {
       if (expense.Cost % 1 !== 0) {
         expense.Cost = Number(expense.Cost).toFixed(2)
       }
+      if (!expense.Cost) {
+        expense.Cost = 0
+      }
     })
 
     return claimExpenses

--- a/app/services/data/get-claim-expense-by-id-or-last-approved.js
+++ b/app/services/data/get-claim-expense-by-id-or-last-approved.js
@@ -5,7 +5,9 @@ module.exports = function (reference, eligibiltyId, claimId) {
   return knex.raw(`SELECT * FROM [IntSchema].[getClaimExpenseByIdOrLastApproved] (?, ?, ?)`, [ reference, eligibiltyId, claimId ])
   .then(function (claimExpenses) {
     claimExpenses.forEach(function (expense) {
-      expense.Cost = Number(expense.Cost).toFixed(2)
+      if (expense.Cost % 1 !== 0) {
+        expense.Cost = Number(expense.Cost).toFixed(2)
+      }
     })
 
     return claimExpenses

--- a/app/services/data/insert-repeat-duplicate-claim.js
+++ b/app/services/data/insert-repeat-duplicate-claim.js
@@ -12,11 +12,14 @@ module.exports = function (reference, eligibilityId, claim) {
   return insertNewClaim(reference, eligibilityId, claimTypeEnum.REPEAT_DUPLICATE, claim)
     .then(function (newClaimId) { claimId = newClaimId })
     .then(function () { return getLastClaimDetails(reference, eligibilityId) })
-    .then(function (claimDetails) { lastClaimDetails = claimDetails })
+    .then(function (claimDetails) {
+      lastClaimDetails = claimDetails
+    })
     .then(function () { return insertClaimDetail('ClaimChild', reference, eligibilityId, claimId, lastClaimDetails.children) })
     .then(function () {
       lastClaimDetails.expenses.forEach(function (expense) {
         delete expense.Status
+        delete expense.RequestedCost
       })
       return insertClaimDetail('ClaimExpense', reference, eligibilityId, claimId, lastClaimDetails.expenses)
     })

--- a/app/services/helpers/sort-view-claim-results-helper.js
+++ b/app/services/helpers/sort-view-claim-results-helper.js
@@ -20,7 +20,15 @@ function sortClaimAndEligibility (claim, eligibility) {
 
 function sortClaimDocumentsAndExpenses (claim, claimDocuments, claimExpenses, externalClaimDocuments) {
   claimExpenses.forEach(function (expense) {
-    expense.Cost = Number(expense.Cost).toFixed(2)
+    if (!expense.Status || expense.Status === 'REQUEST-INFORMATION') {
+      expense.Cost = expense.RequestedCost
+    }
+    if (expense.Cost % 1 !== 0) {
+      expense.Cost = Number(expense.Cost).toFixed(2)
+    }
+    if (!expense.Cost) {
+      expense.Cost = 0
+    }
   })
   var externalDocumentMap = {}
   var multiPageDocuments = []

--- a/test/unit/services/helpers/test-sort-claim-results-helper.js
+++ b/test/unit/services/helpers/test-sort-claim-results-helper.js
@@ -3,7 +3,8 @@ const sortViewClaimResultsHelper = require('../../../../app/services/helpers/sor
 
 var claim
 var advanceClaim
-var claimExpenses = [{ClaimExpenseId: 1, ExpenseType: 'car'}]
+var claimExpenses = [{ClaimExpenseId: 1, ExpenseType: 'car', Cost: 2.2, RequestedCost: 3, Status: 'APPROVED-DIFF-AMOUNT'}]
+var claimExpensesNoStatus = [{ClaimExpenseId: 1, ExpenseType: 'car', RequestedCost: 3}]
 const ELIGIBILITY = {EligibilityId: 1, FirstName: 'tester'}
 const CLAIM_DOCUMENTS = [
   {ClaimDocumentId: 1, DocumentType: 'VISIT-CONFIRMATION'},
@@ -60,5 +61,17 @@ describe('services/helpers/sort-view-claim-results-helper', function () {
     expect(advanceClaim.visitConfirmation.DocumentType).to.equal(CLAIM_DOCUMENTS[0].DocumentType)
     expect(advanceClaim.visitConfirmation.ClaimDocumentId).to.equal(CLAIM_DOCUMENTS[0].ClaimDocumentId)
     expect(advanceClaim.visitConfirmation.fromInternalWeb).to.equal(true)
+  })
+
+  it('an approved claim expenses cost should be used and add decimals', function () {
+    claim = {ClaimId: 1}
+    sortViewClaimResultsHelper(claim, ELIGIBILITY, CLAIM_DOCUMENTS, claimExpenses, [])
+    expect(claimExpenses[0].Cost).to.equal('2.20')
+  })
+
+  it('use requested cost when a claim expense has no status', function () {
+    claim = {ClaimId: 1}
+    sortViewClaimResultsHelper(claim, ELIGIBILITY, CLAIM_DOCUMENTS, claimExpensesNoStatus, [])
+    expect(claimExpensesNoStatus[0].Cost).to.equal(claimExpensesNoStatus[0].RequestedCost)
   })
 })


### PR DESCRIPTION
Now checks status of claim expenses and if they have no status or are in request information status will display the requested cost rather than the approved cost closes #324 issue
 
* Get claim by expense id now returns costs without decimals if they do not need them
* Removes RequestedCost when copying data over
* If status does not exist or is request info will add RequestedCost to Cost
* Updated test for helper to do this

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards
