### PR TITLE
Chore/fix benefit document association with claim

### DIFF
--- a/app/routes/apply/eligibility/claim/claim-summary.js
+++ b/app/routes/apply/eligibility/claim/claim-summary.js
@@ -7,6 +7,7 @@ const claimExpenseHelper = require('../../../../views/helpers/claim-expense-help
 const ClaimSummary = require('../../../../services/domain/claim-summary')
 const ValidationError = require('../../../../services/errors/validation-error')
 const getClaimDocumentFilePath = require('../../../../services/data/get-claim-document-file-path')
+const benefitUploadNotRequired = require('../../../helpers/benefit-upload-not-required')
 const displayHelper = require('../../../../views/helpers/display-helper')
 
 module.exports = function (router) {
@@ -24,6 +25,7 @@ module.exports = function (router) {
             dateHelper: dateHelper,
             claimExpenseHelper: claimExpenseHelper,
             displayHelper: displayHelper,
+            benefitUploadNotRequired: benefitUploadNotRequired(req.params.claimType),
             URL: req.url
           })
       })
@@ -42,7 +44,7 @@ module.exports = function (router) {
         if (claimDetails.claim.benefitDocument.length > 0) {
           benefitDocument = claimDetails.claim.benefitDocument[0]
         }
-        var claimSummary = new ClaimSummary(claimDetails.claim.visitConfirmation, claimDetails.claim.Benefit, benefitDocument, claimDetails.claimExpenses, claimDetails.claim.IsAdvanceClaim) // eslint-disable-line no-unused-vars
+        var claimSummary = new ClaimSummary(claimDetails.claim.visitConfirmation, claimDetails.claim.Benefit, benefitDocument, claimDetails.claimExpenses, claimDetails.claim.IsAdvanceClaim, benefitUploadNotRequired(req.params.claimType)) // eslint-disable-line no-unused-vars
         return res.redirect(`/apply/${req.params.claimType}/eligibility/${req.params.referenceId}/claim/${req.params.claimId}/bank-account-details?isAdvance=${claimDetails.claim.IsAdvanceClaim}`)
       })
       .catch(function (error) {
@@ -56,6 +58,7 @@ module.exports = function (router) {
             dateHelper: dateHelper,
             claimExpenseHelper: claimExpenseHelper,
             displayHelper: displayHelper,
+            benefitUploadNotRequired: benefitUploadNotRequired(req.params.claimType),
             URL: req.url
           })
         } else {

--- a/app/routes/apply/eligibility/claim/file-upload.js
+++ b/app/routes/apply/eligibility/claim/file-upload.js
@@ -78,7 +78,12 @@ function post (req, res, next, redirectURL) {
         if (DocumentTypeEnum.hasOwnProperty(req.query.document)) {
           var fileUpload = new FileUpload(req.params.claimId, req.query.document, req.query.claimExpenseId, req.file, req.error, req.body.alternative)
 
-          ClaimDocumentInsert(reference, id, req.params.claimId, fileUpload).then(function () {
+          var claimId
+          if (req.query.document === DocumentTypeEnum.VISIT_CONFIRMATION || req.query.document === DocumentTypeEnum.RECEIPT) {
+            claimId = req.params.claimId
+          }
+
+          ClaimDocumentInsert(reference, id, claimId, fileUpload).then(function () {
             res.redirect(redirectURL)
           }).catch(function (error) {
             next(error)

--- a/app/routes/apply/eligibility/claim/file-upload.js
+++ b/app/routes/apply/eligibility/claim/file-upload.js
@@ -36,7 +36,7 @@ function get (req, res) {
 
   if (DocumentTypeEnum.hasOwnProperty(req.query.document)) {
     var decryptedRef = getDecryptedReference(req.params)
-    DirectoryCheck(decryptedRef, req.params.claimId, req.query.claimExpenseId, req.query.document)
+    DirectoryCheck(decryptedRef, req.query.claimExpenseId, req.query.document)
     return res.render('apply/eligibility/claim/file-upload', {
       document: req.query.document,
       fileUploadGuidingText: DocumentTypeEnum,
@@ -72,6 +72,7 @@ function post (req, res, next, redirectURL) {
         })
       }
       if (error) {
+        console.log(error)
         throw new ValidationError({upload: [ERROR_MESSAGES.getUploadTooLarge]})
       } else {
         if (DocumentTypeEnum.hasOwnProperty(req.query.document)) {

--- a/app/routes/apply/eligibility/claim/file-upload.js
+++ b/app/routes/apply/eligibility/claim/file-upload.js
@@ -79,7 +79,7 @@ function post (req, res, next, redirectURL) {
           var fileUpload = new FileUpload(req.params.claimId, req.query.document, req.query.claimExpenseId, req.file, req.error, req.body.alternative)
 
           var claimId
-          if (req.query.document === DocumentTypeEnum.VISIT_CONFIRMATION || req.query.document === DocumentTypeEnum.RECEIPT) {
+          if (req.query.document === 'VISIT_CONFIRMATION' || req.query.document === 'RECEIPT') {
             claimId = req.params.claimId
           }
 

--- a/app/routes/apply/eligibility/claim/file-upload.js
+++ b/app/routes/apply/eligibility/claim/file-upload.js
@@ -36,7 +36,8 @@ function get (req, res) {
 
   if (DocumentTypeEnum.hasOwnProperty(req.query.document)) {
     var decryptedRef = getDecryptedReference(req.params)
-    DirectoryCheck(decryptedRef, req.query.claimExpenseId, req.query.document)
+    var claimId = addClaimIdIfNotBenefitDocument(req.query.document, req.params.claimId)
+    DirectoryCheck(decryptedRef, claimId, req.query.claimExpenseId, req.query.document)
     return res.render('apply/eligibility/claim/file-upload', {
       document: req.query.document,
       fileUploadGuidingText: DocumentTypeEnum,
@@ -78,10 +79,7 @@ function post (req, res, next, redirectURL) {
         if (DocumentTypeEnum.hasOwnProperty(req.query.document)) {
           var fileUpload = new FileUpload(req.params.claimId, req.query.document, req.query.claimExpenseId, req.file, req.error, req.body.alternative)
 
-          var claimId
-          if (req.query.document === 'VISIT_CONFIRMATION' || req.query.document === 'RECEIPT') {
-            claimId = req.params.claimId
-          }
+          var claimId = addClaimIdIfNotBenefitDocument(req.query.document, req.params.claimId)
 
           ClaimDocumentInsert(reference, id, claimId, fileUpload).then(function () {
             res.redirect(redirectURL)
@@ -114,6 +112,14 @@ function getDecryptedReference (requestParams) {
     return decrypt(requestParams.referenceId)
   } else if (requestParams.reference) {
     return decrypt(requestParams.reference)
+  } else {
+    return null
+  }
+}
+
+function addClaimIdIfNotBenefitDocument (document, claimId) {
+  if (document === 'VISIT_CONFIRMATION' || document === 'RECEIPT') {
+    return claimId
   } else {
     return null
   }

--- a/app/routes/helpers/benefit-upload-not-required.js
+++ b/app/routes/helpers/benefit-upload-not-required.js
@@ -1,0 +1,9 @@
+const claimTypeEnum = require('../../constants/claim-type-enum')
+
+module.exports = function (claimType) {
+  var uploadNotRequired = false
+  if (claimType === claimTypeEnum.REPEAT_CLAIM || claimType === claimTypeEnum.REPEAT_DUPLICATE) {
+    uploadNotRequired = true
+  }
+  return uploadNotRequired
+}

--- a/app/services/data/get-all-claim-documents-by-claim-id.js
+++ b/app/services/data/get-all-claim-documents-by-claim-id.js
@@ -1,9 +1,10 @@
 const config = require('../../../knexfile').extweb
 const knex = require('knex')(config)
 
-module.exports = function (claimId) {
+module.exports = function (claimId, reference, eligibilityId) {
   return knex('ClaimDocument')
     .where({'ClaimDocument.ClaimId': claimId, 'ClaimDocument.IsEnabled': true})
+    .orWhere({'ClaimDocument.ClaimId': null, 'ClaimDocument.Reference': reference, 'ClaimDocument.EligibilityId': eligibilityId, 'ClaimDocument.IsEnabled': true})
     .select('ClaimDocument.DocumentStatus', 'ClaimDocument.DocumentType', 'ClaimDocument.ClaimDocumentId', 'ClaimDocument.ClaimExpenseId')
     .orderBy('ClaimDocument.DateSubmitted', 'desc')
 }

--- a/app/services/data/get-claim-documents-historic-claim.js
+++ b/app/services/data/get-claim-documents-historic-claim.js
@@ -1,6 +1,6 @@
 const config = require('../../../knexfile').extweb
 const knex = require('knex')(config)
 
-module.exports = function (reference, claimId) {
-  return knex.raw(`SELECT * FROM [IntSchema].[getClaimDocumentsHistoricClaim] (?, ?)`, [ reference, claimId ])
+module.exports = function (reference, eligibilityId, claimId) {
+  return knex.raw(`SELECT * FROM [IntSchema].[getClaimDocumentsHistoricClaim] (?, ?, ?)`, [ reference, eligibilityId, claimId ])
 }

--- a/app/services/data/get-claim-summary.js
+++ b/app/services/data/get-claim-summary.js
@@ -48,8 +48,13 @@ module.exports = function (claimId, claimType) {
     })
     .then(function (claim) {
       return knex('ClaimDocument')
-        .join('Claim', 'ClaimDocument.ClaimId', '=', 'Claim.ClaimId')
-        .where({'Claim.ClaimId': claimId, 'ClaimDocument.IsEnabled': true, 'ClaimDocument.ClaimExpenseId': null})
+        .where({'ClaimDocument.ClaimId': claimId, 'ClaimDocument.IsEnabled': true, 'ClaimDocument.ClaimExpenseId': null})
+        .orWhere({
+          'ClaimDocument.ClaimId': null,
+          'ClaimDocument.Reference': claim.Reference,
+          'ClaimDocument.EligibilityId': claim.EligibilityId,
+          'ClaimDocument.IsEnabled': true,
+          'ClaimDocument.ClaimExpenseId': null})
         .select('ClaimDocument.DocumentStatus', 'ClaimDocument.DocumentType', 'ClaimDocument.ClaimDocumentId')
         .orderBy('ClaimDocument.DateSubmitted', 'desc')
         .then(function (claimDocuments) {

--- a/app/services/data/get-view-claim.js
+++ b/app/services/data/get-view-claim.js
@@ -9,28 +9,30 @@ const sortViewClaimResults = require('../helpers/sort-view-claim-results-helper'
 const Promise = require('bluebird')
 
 module.exports = function (claimId, reference, dob) {
-  return Promise.all([getHistoricClaimByClaimId(reference, dob, claimId),
-    getRepeatEligibility(reference, dob, null),
-    getClaimDocumentsHistoricClaim(reference, claimId),
-    getClaimExpenseByIdOrLastApproved(reference, null, claimId),
-    getAllClaimDocumentsByClaimId(claimId),
-    getClaimEvents(reference, claimId),
-    getClaimChildrenByIdOrLastApproved(reference, null, claimId)
-  ])
-    .then(function (results) {
-      var claim = results[0][0]
-      var eligibility = results[1]
-      var claimDocuments = results[2]
-      var claimExpenses = results[3]
-      var externalClaimDocuments = results[4]
-      var claimEvents = results[5]
-      var claimChild = results[6]
-      sortViewClaimResults(claim, eligibility, claimDocuments, claimExpenses, externalClaimDocuments)
-      return {
-        claim: claim,
-        claimExpenses: claimExpenses,
-        claimEvents: claimEvents,
-        claimChild: claimChild
-      }
+  return getHistoricClaimByClaimId(reference, dob, claimId)
+    .then(function (historicClaim) {
+      var claim = historicClaim[0]
+      return Promise.all([getRepeatEligibility(reference, dob, null),
+        getClaimDocumentsHistoricClaim(reference, claim.EligibilityId, claimId),
+        getClaimExpenseByIdOrLastApproved(reference, null, claimId),
+        getAllClaimDocumentsByClaimId(claimId, reference, claim.EligibilityId),
+        getClaimEvents(reference, claimId),
+        getClaimChildrenByIdOrLastApproved(reference, null, claimId)
+      ])
+        .then(function (results) {
+          var eligibility = results[0]
+          var claimDocuments = results[1]
+          var claimExpenses = results[2]
+          var externalClaimDocuments = results[3]
+          var claimEvents = results[4]
+          var claimChild = results[5]
+          sortViewClaimResults(claim, eligibility, claimDocuments, claimExpenses, externalClaimDocuments)
+          return {
+            claim: claim,
+            claimExpenses: claimExpenses,
+            claimEvents: claimEvents,
+            claimChild: claimChild
+          }
+        })
     })
 }

--- a/app/services/directory-check.js
+++ b/app/services/directory-check.js
@@ -2,12 +2,12 @@ const config = require('../../config')
 var fs = require('fs')
 var mkdirp = require('mkdirp')
 
-module.exports = function (referenceId, claimId, claimExpenseId, documentType) {
+module.exports = function (referenceId, claimExpenseId, documentType) {
   var path
   if (!claimExpenseId) {
-    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimId}/${documentType}`
+    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${documentType}`
   } else {
-    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimId}/${claimExpenseId}/${documentType}`
+    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimExpenseId}/${documentType}`
   }
   if (!fs.existsSync(path)) {
     mkdirp.sync(path)

--- a/app/services/directory-check.js
+++ b/app/services/directory-check.js
@@ -2,12 +2,14 @@ const config = require('../../config')
 var fs = require('fs')
 var mkdirp = require('mkdirp')
 
-module.exports = function (referenceId, claimExpenseId, documentType) {
+module.exports = function (referenceId, claimId, claimExpenseId, documentType) {
   var path
-  if (!claimExpenseId) {
+  if (!claimId) {
     path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${documentType}`
+  } else if (!claimExpenseId) {
+    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimId}/${documentType}`
   } else {
-    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimExpenseId}/${documentType}`
+    path = `${config.FILE_UPLOAD_LOCATION}/${referenceId}/${claimId}/${claimExpenseId}/${documentType}`
   }
   if (!fs.existsSync(path)) {
     mkdirp.sync(path)

--- a/app/services/domain/claim-summary.js
+++ b/app/services/domain/claim-summary.js
@@ -5,19 +5,20 @@ const BenefitEnum = require('../../constants/benefits-enum')
 const DisplayHelper = require('../../views/helpers/display-helper')
 
 class ClaimSummary {
-  constructor (visitConfirmation, benefit, benefitDocument, claimExpenses, isAdvanceClaim) {
+  constructor (visitConfirmation, benefit, benefitDocument, claimExpenses, isAdvanceClaim, benefitUploadNotRequired) {
     this.benefit = benefit
     this.claimExpenses = claimExpenses
     this.benefitDocumentStatus = benefitDocument ? benefitDocument.DocumentStatus : ''
     this.visitConfirmationStatus = visitConfirmation ? visitConfirmation.DocumentStatus : ''
     this.isAdvanceClaim = isAdvanceClaim
+    this.benefitUploadNotRequired = benefitUploadNotRequired
     this.isValid()
   }
 
   isValid () {
     var errors = ErrorHandler()
 
-    if (BenefitEnum.getByValue(this.benefit).requireBenefitUpload) {
+    if (BenefitEnum.getByValue(this.benefit).requireBenefitUpload && !this.benefitUploadNotRequired) {
       FieldValidator(this.benefitDocumentStatus, 'benefit-information', errors)
         .isRequired()
     }

--- a/app/services/upload.js
+++ b/app/services/upload.js
@@ -13,7 +13,7 @@ var storage = multer.diskStorage({
   destination: function (req, file, cb) {
     var decryptedReferenceId = decrypt(req.params.referenceId)
 
-    if (req.query.document !== 'VISIT_CONFIRMATION' || req.query.document !== 'RECEIPT') {
+    if (req.query.document !== 'VISIT_CONFIRMATION' && req.query.document !== 'RECEIPT') {
       cb(null, `${config.FILE_UPLOAD_LOCATION}/${decryptedReferenceId}/${req.query.document}`)
     } else if (req.query.claimExpenseId) {
       cb(null, `${config.FILE_UPLOAD_LOCATION}/${decryptedReferenceId}/${req.params.claimId}/${req.query.claimExpenseId}/${req.query.document}`)

--- a/app/services/upload.js
+++ b/app/services/upload.js
@@ -14,9 +14,9 @@ var storage = multer.diskStorage({
     var decryptedReferenceId = decrypt(req.params.referenceId)
 
     if (req.query.claimExpenseId) {
-      cb(null, `${config.FILE_UPLOAD_LOCATION}/${decryptedReferenceId}/${req.params.claimId}/${req.query.claimExpenseId}/${req.query.document}`)
+      cb(null, `${config.FILE_UPLOAD_LOCATION}/${decryptedReferenceId}/${req.query.claimExpenseId}/${req.query.document}`)
     } else {
-      cb(null, `${config.FILE_UPLOAD_LOCATION}/${decryptedReferenceId}/${req.params.claimId}/${req.query.document}`)
+      cb(null, `${config.FILE_UPLOAD_LOCATION}/${decryptedReferenceId}/${req.query.document}`)
     }
   },
   filename: function (req, file, cb) {

--- a/app/services/upload.js
+++ b/app/services/upload.js
@@ -13,10 +13,12 @@ var storage = multer.diskStorage({
   destination: function (req, file, cb) {
     var decryptedReferenceId = decrypt(req.params.referenceId)
 
-    if (req.query.claimExpenseId) {
-      cb(null, `${config.FILE_UPLOAD_LOCATION}/${decryptedReferenceId}/${req.query.claimExpenseId}/${req.query.document}`)
-    } else {
+    if (req.query.document !== 'VISIT_CONFIRMATION' || req.query.document !== 'RECEIPT') {
       cb(null, `${config.FILE_UPLOAD_LOCATION}/${decryptedReferenceId}/${req.query.document}`)
+    } else if (req.query.claimExpenseId) {
+      cb(null, `${config.FILE_UPLOAD_LOCATION}/${decryptedReferenceId}/${req.params.claimId}/${req.query.claimExpenseId}/${req.query.document}`)
+    } else {
+      cb(null, `${config.FILE_UPLOAD_LOCATION}/${decryptedReferenceId}/${req.params.claimId}/${req.query.document}`)
     }
   },
   filename: function (req, file, cb) {

--- a/app/views/partials/claim-summary/claim-summary-visitor.html
+++ b/app/views/partials/claim-summary/claim-summary-visitor.html
@@ -73,14 +73,14 @@
             {% else %}
               <span class="text-success">Benefit documentation uploaded</span>
               <form
-                action="{{ URL }}/view-document/{{ claimDetails.claim.benefitDocument[0]['ClaimDocumentId'] }}&eligibilityId={{ claimDetails.claim.EligibilityId }}"
+                action="{{ URL }}/view-document/{{ claimDetails.claim.benefitDocument[0]['ClaimDocumentId'] }}"
                 method="get" class="form pull-right">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}">
                 <button class="link">view</button>
               </form>
               <span class="button-separator"></span>
               <form
-                action="/{{ URL }}/remove-document/{{ claimDetails.claim.benefitDocument[0]['ClaimDocumentId'] }}?document={{ claimDetails.claim['Benefit'] }}&eligibilityId={{ claimDetails.claim.EligibilityId }}"
+                action="{{ URL }}/remove-document/{{ claimDetails.claim.benefitDocument[0]['ClaimDocumentId'] }}?document={{ claimDetails.claim['Benefit'] }}&eligibilityId={{ claimDetails.claim.EligibilityId }}"
                 method="post" class="form pull-right">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}">
                 <button class="remove link" name="remove">remove</button>
@@ -102,6 +102,8 @@
               <input type="hidden" name="_csrf" value="{{ csrfToken }}">
               <button class="link" name="change" id="change-{{ claimDetails.claim['Benefit'] }}-post">change</button>
             </form>
+          {% elif benefitUploadNotRequired %}
+            <span class="text-success">Benefit document previously uploaded</span>
           {% else %}
             <span class="text-warning">Benefit documentation needed</span>
             <a href="{{ URL }}/file-upload?document={{ claimDetails.claim['Benefit'] }}&eligibilityId={{ claimDetails.claim.EligibilityId }}" id="add-benefit" class="button grey pull-right">Add</a>

--- a/migrations/20170113152932_remove-not-null-on-claimId-claim-document.js
+++ b/migrations/20170113152932_remove-not-null-on-claimId-claim-document.js
@@ -1,0 +1,15 @@
+exports.up = function (knex, Promise) {
+  return knex.raw('ALTER TABLE ExtSchema.ClaimDocument ALTER COLUMN ClaimId INT NULL')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
+}
+
+exports.down = function (knex, Promise) {
+  return knex.raw('ALTER TABLE ExtSchema.ClaimDocument ALTER COLUMN ClaimId INT NOT NULL')
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
+}

--- a/test/helpers/data/claim-helper.js
+++ b/test/helpers/data/claim-helper.js
@@ -45,7 +45,7 @@ module.exports.insertWithExpenseChildDocuments = function (reference, eligibilit
     .then(function () {
       return claimDocumentHelper.insert(reference, eligibilityId, claimId, claimDocumentHelper.DOCUMENT_TYPE)
         .then(function () {
-          return claimDocumentHelper.insert(reference, eligibilityId, claimId, 'BENEFIT')
+          return claimDocumentHelper.insert(reference, eligibilityId, null, 'BENEFIT')
         })
     })
     .then(function () {

--- a/test/integration/services/data/test-get-all-claim-documents-by-claim-id.js
+++ b/test/integration/services/data/test-get-all-claim-documents-by-claim-id.js
@@ -31,8 +31,8 @@ describe('services/data/get-all-claim-documents-by-claim-id', function () {
       })
   })
 
-  it('should return a ClaimDocument file path', function () {
-    return getAllClaimDocumentsByClaimId(claimId)
+  it('should return a ClaimDocument', function () {
+    return getAllClaimDocumentsByClaimId(claimId, REFERENCE, eligibilityId)
       .then(function (result) {
         expect(result.length).to.equal(1)
         expect(result[0].DocumentType).to.equal(claimDocumentHelper.DOCUMENT_TYPE)

--- a/test/integration/services/data/test-get-claim-documents-historic-claim.js
+++ b/test/integration/services/data/test-get-claim-documents-historic-claim.js
@@ -7,11 +7,13 @@ describe('services/data/get-claim-documents-historic-claim', function () {
   const REFERENCE = 'HISTDOC'
   const INVALID_REFERENCE = 'INVALID'
   var claimId
+  var eligibilityId
 
   before(function () {
     return internalEligiblityHelper.insertEligibilityAndClaim(REFERENCE)
       .then(function (ids) {
         claimId = ids.claimId
+        eligibilityId = ids.eligibilityId
       })
   })
 
@@ -20,7 +22,7 @@ describe('services/data/get-claim-documents-historic-claim', function () {
   })
 
   it('should retrieve all claim documents given reference and claimId', function () {
-    return getClaimDocumentsHistoricClaim(REFERENCE, claimId)
+    return getClaimDocumentsHistoricClaim(REFERENCE, eligibilityId, claimId)
       .then(function (documents) {
         expect(documents.length).to.be.equal(2)
         expect(documents[0].DocumentType).to.be.equal(internalClaimDocumentHelper.DOCUMENT_TYPE)

--- a/test/unit/routes/helpers/test-benefit-upload-noot-required.js
+++ b/test/unit/routes/helpers/test-benefit-upload-noot-required.js
@@ -1,0 +1,15 @@
+const expect = require('chai').expect
+const claimTypeEnum = require('../../../../app/constants/claim-type-enum')
+const benefitUploadNotRequired = require('../../../../app/routes/helpers/benefit-upload-not-required')
+
+describe('routes/helpers/benefit-upload-not-required', function () {
+  it('should return true for repeat claims with no new eligibility', function () {
+    expect(benefitUploadNotRequired(claimTypeEnum.REPEAT_CLAIM)).to.be.true
+    expect(benefitUploadNotRequired(claimTypeEnum.REPEAT_DUPLICATE)).to.be.true
+  })
+
+  it('should return false for first-time claims and repeat with eligibility changes', function () {
+    expect(benefitUploadNotRequired(claimTypeEnum.FIRST_TIME)).to.be.false
+    expect(benefitUploadNotRequired(claimTypeEnum.REPEAT_NEW_ELIGIBILITY)).to.be.false
+  })
+})

--- a/test/unit/services/data/test-get-view-claim.js
+++ b/test/unit/services/data/test-get-view-claim.js
@@ -6,6 +6,7 @@ require('sinon-bluebird')
 const REFERENCE = 'V123456'
 const CLAIMID = 1234
 const DOB = '10-10-1990'
+const ELIGIBILITYID = 1234
 
 describe('services/data/get-view-claim', function () {
   var getViewClaim
@@ -22,7 +23,7 @@ describe('services/data/get-view-claim', function () {
     getRepeatEligibilityStub = sinon.stub().resolves([[]])
     getClaimExpenseByIdOrLastApprovedStub = sinon.stub().resolves([])
     getClaimChildrenByIdOrLastApprovedStub = sinon.stub().resolves([])
-    getHistoricClaimByClaimIdStub = sinon.stub().resolves([])
+    getHistoricClaimByClaimIdStub = sinon.stub().resolves([{EligibilityId: ELIGIBILITYID}])
     getClaimDocumentsHistoricClaimStub = sinon.stub().resolves([])
     getAllClaimDocumentsByClaimIdStub = sinon.stub().resolves([])
     getClaimEventsStub = sinon.stub().resolves([])
@@ -47,8 +48,8 @@ describe('services/data/get-view-claim', function () {
         expect(getClaimExpenseByIdOrLastApprovedStub.calledWith(REFERENCE, null, CLAIMID)).to.be.true
         expect(getClaimChildrenByIdOrLastApprovedStub.calledWith(REFERENCE, null, CLAIMID)).to.be.true
         expect(getHistoricClaimByClaimIdStub.calledWith(REFERENCE, DOB, CLAIMID)).to.be.true
-        expect(getClaimDocumentsHistoricClaimStub.calledWith(REFERENCE, CLAIMID)).to.be.true
-        expect(getAllClaimDocumentsByClaimIdStub.calledWith(CLAIMID)).to.be.true
+        expect(getClaimDocumentsHistoricClaimStub.calledWith(REFERENCE, ELIGIBILITYID, CLAIMID)).to.be.true
+        expect(getAllClaimDocumentsByClaimIdStub.calledWith(CLAIMID, REFERENCE, ELIGIBILITYID)).to.be.true
         sinon.assert.calledOnce(sortViewClaimResultsHelperStub)
       })
   })

--- a/test/unit/services/domain/test-claim-summary.js
+++ b/test/unit/services/domain/test-claim-summary.js
@@ -11,22 +11,23 @@ describe('services/domain/claim-summary', function () {
   const VALID_IS_ADVANCE_CLAIM = false
   const INVALID_VISIT_CONFIRMATION = ''
   const INVALID_BENEFIT_DOCUMENT = ''
+  const BENEFIT_UPLOAD_NOT_REQUIRED = false
   const VALID_CLAIM_EXPENSE_DOCUMENT = [{ExpenseType: 'bus', DocumentStatus: 'uploaded'}]
   const INVALID_CLAIM_EXPENSE_DOCUMENT = [{ExpenseType: 'test', DocumentStatus: null}]
 
   it('should construct a domain object given valid input', function () {
-    claimSummary = new ClaimSummary(VALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, VALID_BENEFIT_DOCUMENT, VALID_CLAIM_EXPENSE_DOCUMENT, VALID_IS_ADVANCE_CLAIM)
+    claimSummary = new ClaimSummary(VALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, VALID_BENEFIT_DOCUMENT, VALID_CLAIM_EXPENSE_DOCUMENT, VALID_IS_ADVANCE_CLAIM, BENEFIT_UPLOAD_NOT_REQUIRED)
     expect(claimSummary.visitConfirmationStatus).to.equal(VALID_VISIT_CONFIRMATION.DocumentStatus)
   })
 
   it('should construct a domain object given valid input for a benefit that does not need a document', function () {
-    claimSummary = new ClaimSummary(VALID_VISIT_CONFIRMATION, VALID_BENEFIT_NO_UPLOAD, INVALID_BENEFIT_DOCUMENT, VALID_CLAIM_EXPENSE_DOCUMENT, VALID_IS_ADVANCE_CLAIM)
+    claimSummary = new ClaimSummary(VALID_VISIT_CONFIRMATION, VALID_BENEFIT_NO_UPLOAD, INVALID_BENEFIT_DOCUMENT, VALID_CLAIM_EXPENSE_DOCUMENT, VALID_IS_ADVANCE_CLAIM, BENEFIT_UPLOAD_NOT_REQUIRED)
     expect(claimSummary.visitConfirmationStatus).to.equal(VALID_VISIT_CONFIRMATION.DocumentStatus)
   })
 
   it('should return an isRequired validation error given no visit confirmation', function () {
     try {
-      claimSummary = new ClaimSummary(INVALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, VALID_BENEFIT_DOCUMENT, VALID_CLAIM_EXPENSE_DOCUMENT, VALID_IS_ADVANCE_CLAIM)
+      claimSummary = new ClaimSummary(INVALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, VALID_BENEFIT_DOCUMENT, VALID_CLAIM_EXPENSE_DOCUMENT, VALID_IS_ADVANCE_CLAIM, BENEFIT_UPLOAD_NOT_REQUIRED)
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
       expect(e.validationErrors['VisitConfirmation'][0]).to.equal('Visit confirmation is required')
@@ -34,12 +35,12 @@ describe('services/domain/claim-summary', function () {
   })
 
   it('should not return an isRequired validation error given no visit confirmation for advance claim', function () {
-    claimSummary = new ClaimSummary(INVALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, VALID_BENEFIT_DOCUMENT, VALID_CLAIM_EXPENSE_DOCUMENT, true)
+    claimSummary = new ClaimSummary(INVALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, VALID_BENEFIT_DOCUMENT, VALID_CLAIM_EXPENSE_DOCUMENT, true, BENEFIT_UPLOAD_NOT_REQUIRED)
   })
 
   it('should return an isRequired validation error given no benefit document', function () {
     try {
-      claimSummary = new ClaimSummary(VALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, INVALID_BENEFIT_DOCUMENT, VALID_CLAIM_EXPENSE_DOCUMENT, VALID_IS_ADVANCE_CLAIM)
+      claimSummary = new ClaimSummary(VALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, INVALID_BENEFIT_DOCUMENT, VALID_CLAIM_EXPENSE_DOCUMENT, VALID_IS_ADVANCE_CLAIM, BENEFIT_UPLOAD_NOT_REQUIRED)
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
       expect(e.validationErrors['benefit-information'][0]).to.equal('Benefit information is required')
@@ -48,7 +49,7 @@ describe('services/domain/claim-summary', function () {
 
   it('should return an isRequired validation error given no claim expense document', function () {
     try {
-      claimSummary = new ClaimSummary(VALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, VALID_BENEFIT_DOCUMENT, INVALID_CLAIM_EXPENSE_DOCUMENT, VALID_IS_ADVANCE_CLAIM)
+      claimSummary = new ClaimSummary(VALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, VALID_BENEFIT_DOCUMENT, INVALID_CLAIM_EXPENSE_DOCUMENT, VALID_IS_ADVANCE_CLAIM, BENEFIT_UPLOAD_NOT_REQUIRED)
     } catch (e) {
       expect(e).to.be.instanceof(ValidationError)
       expect(e.validationErrors['claim-expense'][0]).to.equal('Claim expense receipt is required')
@@ -56,6 +57,6 @@ describe('services/domain/claim-summary', function () {
   })
 
   it('should not return an isRequired validation error given no claim expense document for advance claim', function () {
-    claimSummary = new ClaimSummary(VALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, VALID_BENEFIT_DOCUMENT, INVALID_CLAIM_EXPENSE_DOCUMENT, true)
+    claimSummary = new ClaimSummary(VALID_VISIT_CONFIRMATION, VALID_BENEFIT_UPLOAD_NEEDED, VALID_BENEFIT_DOCUMENT, INVALID_CLAIM_EXPENSE_DOCUMENT, true, BENEFIT_UPLOAD_NOT_REQUIRED)
   })
 })

--- a/test/unit/services/test-directory-check.js
+++ b/test/unit/services/test-directory-check.js
@@ -2,18 +2,18 @@ var expect = require('chai').expect
 var directoryCheck = require('../../../app/services/directory-check')
 const config = require('../../../config')
 var fs = require('fs')
-var normalDocumentPath = `${config.FILE_UPLOAD_LOCATION}/1/1/1`
-var claimExpensePath = `${config.FILE_UPLOAD_LOCATION}/1/1/1/1`
+var normalDocumentPath = `${config.FILE_UPLOAD_LOCATION}/1/1`
+var claimExpensePath = `${config.FILE_UPLOAD_LOCATION}/1/1/1`
 
 describe('services/directory-check', function () {
   it('check and see creates a directory is created for a doc without claimExpenseId', function () {
-    directoryCheck('1', '1', undefined, '1')
+    directoryCheck('1', undefined, '1')
     expect(fs.existsSync(normalDocumentPath)).to.equal(true)
     expect(fs.existsSync(claimExpensePath)).to.equal(false)
   })
 
   it('check and see creates a directory is created for a doc with claimExpenseId', function () {
-    directoryCheck('1', '1', '1', '1')
+    directoryCheck('1', '1', '1')
     expect(fs.existsSync(claimExpensePath)).to.equal(true)
   })
 
@@ -22,7 +22,6 @@ describe('services/directory-check', function () {
       fs.rmdirSync(claimExpensePath)
     }
     fs.rmdirSync(normalDocumentPath)
-    fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/1/1`)
     fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/1`)
   })
 })

--- a/test/unit/services/test-directory-check.js
+++ b/test/unit/services/test-directory-check.js
@@ -2,26 +2,42 @@ var expect = require('chai').expect
 var directoryCheck = require('../../../app/services/directory-check')
 const config = require('../../../config')
 var fs = require('fs')
-var normalDocumentPath = `${config.FILE_UPLOAD_LOCATION}/1/1`
-var claimExpensePath = `${config.FILE_UPLOAD_LOCATION}/1/1/1`
+var benefitPath = `${config.FILE_UPLOAD_LOCATION}/REFNUM1/hc2`
+var visitConfirmationPath = `${config.FILE_UPLOAD_LOCATION}/REFNUM1/1234/VISIT_CONFIRMATION`
+var claimExpensePath = `${config.FILE_UPLOAD_LOCATION}/REFNUM1/1234/5678/RECEIPT`
 
 describe('services/directory-check', function () {
   it('check and see creates a directory is created for a doc without claimExpenseId', function () {
-    directoryCheck('1', undefined, '1')
-    expect(fs.existsSync(normalDocumentPath)).to.equal(true)
+    directoryCheck('REFNUM1', '1234', undefined, 'VISIT_CONFIRMATION')
+    expect(fs.existsSync(visitConfirmationPath)).to.equal(true)
     expect(fs.existsSync(claimExpensePath)).to.equal(false)
   })
 
   it('check and see creates a directory is created for a doc with claimExpenseId', function () {
-    directoryCheck('1', '1', '1')
+    directoryCheck('REFNUM1', '1234', '5678', 'RECEIPT')
+    expect(fs.existsSync(claimExpensePath)).to.equal(true)
+  })
+
+  it('check and see creates a directory is created for a doc without claimId ie benefit documents', function () {
+    directoryCheck('REFNUM1', null, undefined, 'hc2')
     expect(fs.existsSync(claimExpensePath)).to.equal(true)
   })
 
   after(function () {
     if (fs.existsSync(claimExpensePath)) {
       fs.rmdirSync(claimExpensePath)
+      fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/REFNUM1/1234/5678`)
     }
-    fs.rmdirSync(normalDocumentPath)
-    fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/1`)
+    if (fs.existsSync(visitConfirmationPath)) {
+      fs.rmdirSync(visitConfirmationPath)
+    }
+    if (fs.existsSync(benefitPath)) {
+      fs.rmdirSync(benefitPath)
+    }
+
+    if (fs.existsSync(`${config.FILE_UPLOAD_LOCATION}/REFNUM1/1234`)) {
+      fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/REFNUM1/1234`)
+    }
+    fs.rmdirSync(`${config.FILE_UPLOAD_LOCATION}/REFNUM1`)
   })
 })


### PR DESCRIPTION
Updated the claim documents to not associate all docs with a particular claim so benefit documents do not need reuploaded every claim closes #325
 
* Updated fetches to claim summary and view claim to look for claimId being null
* Updated check directory to not use claimId
* Updated view to not look for benefit documents on repeat and repeat duplicate claims
* Updated file upload page to not include claimId if it is a benefit document when making a claim document

## Checklist

- [x] Unit tests
- [x] End-to-End tests
- [x] Code coverage checked
- [x] Coding standards
