### PR TITLE
Fix conversion error when making repeat claim

### DIFF
--- a/app/services/data/get-claim-expense-by-id-or-last-approved.js
+++ b/app/services/data/get-claim-expense-by-id-or-last-approved.js
@@ -5,11 +5,10 @@ module.exports = function (reference, eligibiltyId, claimId) {
   return knex.raw(`SELECT * FROM [IntSchema].[getClaimExpenseByIdOrLastApproved] (?, ?, ?)`, [ reference, eligibiltyId, claimId ])
   .then(function (claimExpenses) {
     claimExpenses.forEach(function (expense) {
-      if (expense.Cost % 1 !== 0) {
-        expense.Cost = Number(expense.Cost).toFixed(2)
-      }
       if (!expense.Cost) {
         expense.Cost = 0
+      } else {
+        expense.Cost = Number(expense.Cost).toFixed(2)
       }
     })
 

--- a/app/services/data/get-last-claim-details.js
+++ b/app/services/data/get-last-claim-details.js
@@ -15,7 +15,6 @@ module.exports = function (reference, eligibilityId) {
       return getClaimEscortByIdOrLastApproved(reference, eligibilityId, null)
     })
     .then(function (lastClaimEscort) {
-      console.dir(lastClaimEscort)
       result.escort = lastClaimEscort
 
       return result

--- a/app/services/data/insert-repeat-duplicate-claim.js
+++ b/app/services/data/insert-repeat-duplicate-claim.js
@@ -20,7 +20,6 @@ module.exports = function (reference, eligibilityId, claim) {
       lastClaimDetails.expenses.forEach(function (expense) {
         delete expense.Status
         delete expense.RequestedCost
-        expense.Cost = expense.Cost.toString()
       })
       return insertClaimDetail('ClaimExpense', reference, eligibilityId, claimId, lastClaimDetails.expenses)
     })

--- a/app/services/data/insert-repeat-duplicate-claim.js
+++ b/app/services/data/insert-repeat-duplicate-claim.js
@@ -20,6 +20,7 @@ module.exports = function (reference, eligibilityId, claim) {
       lastClaimDetails.expenses.forEach(function (expense) {
         delete expense.Status
         delete expense.RequestedCost
+        expense.Cost = expense.Cost.toString()
       })
       return insertClaimDetail('ClaimExpense', reference, eligibilityId, claimId, lastClaimDetails.expenses)
     })


### PR DESCRIPTION
Modified get-claim-expenses-by-id-or-last-approved so that the Cost field will always be formatted as a string with 2 decimal places. 
Fixes error when inserting claim expenses for repeat duplicates.  Issue was caused because table function was returning Cost as an integer for whole numbers, and a string for numbers with decimal places.