### PR TITLE
Fixed upload later and post later with new malware checks

### DIFF
--- a/app/routes/apply/eligibility/claim/file-upload.js
+++ b/app/routes/apply/eligibility/claim/file-upload.js
@@ -37,9 +37,13 @@ module.exports = function (router) {
       checkForMalware(req, res, next, `/apply/${req.params.claimType}/eligibility/${req.params.referenceId}/claim/${req.params.claimId}/summary`)
     })
 
-  router.post('/your-claims/:dob/:reference/:claimId/file-upload', function (req, res, next) {
-    post(req, res, next, `/your-claims/${req.params.dob}/${req.params.reference}/${req.params.claimId}`)
-  })
+  router.post('/your-claims/:dob/:reference/:claimId/file-upload',
+    function (req, res, next) {
+      post(req, res, next)
+    },
+    function (req, res, next) {
+      checkForMalware(req, res, next, `/your-claims/${req.params.dob}/${req.params.reference}/${req.params.claimId}`)
+    })
 }
 
 function get (req, res) {
@@ -91,8 +95,8 @@ function post (req, res, next, redirectURL) {
 
 function checkForMalware (req, res, next, redirectURL) {
   var ids = setReferenceIds(req)
+  var claimId = addClaimIdIfNotBenefitDocument(req.query.document, req.params.claimId)
   if (req.file) {
-    var claimId = addClaimIdIfNotBenefitDocument(req.query.document, req.params.claimId)
     clam.scan(req.file.path).then((infected) => {
       try {
         if (infected) {


### PR DESCRIPTION
Fixed problems with post and upload later and problems with view claim uploads -> fixes e2e tests
 
* Moved addClaimIdIfNotBenefitDocument so it takes place for upload later and post later
* Added check for malware when coming from view claims page so upload later and post later will work

## Checklist

- [x] Unit tests
- [x] End-to-End tests
- [x] Code coverage checked
- [x] Coding standards
