### PR TITLE
If the Clam AV child process fails for some reason, then handle the error

### DIFF
--- a/app/routes/apply/eligibility/claim/file-upload.js
+++ b/app/routes/apply/eligibility/claim/file-upload.js
@@ -111,6 +111,11 @@ function checkForMalware (req, res, next, redirectURL) {
       } catch (error) {
         handleError(req, res, next, error)
       }
+    }).catch((error) => {
+      error.message = 'Virus scan failed whilst calling Clam AV executable'
+      logger.error(error)
+      if (req.file) fs.unlinkAsync(req.file.path).catch()
+      handleError(req, res, next, new Error('There was an error processing your file'))
     })
   } else {
     // This handles the case were Post/Upload Later is selected, so no actual file is being provided,


### PR DESCRIPTION
- Also ensure that in this case the temp file is removed as this is usually
  handled by the scan