### PR TITLE
Chore/alter claim refence and eligibilityid fields to fix issue

### DIFF
--- a/migrations/20161112173218_add-claim-expense.js
+++ b/migrations/20161112173218_add-claim-expense.js
@@ -1,8 +1,8 @@
 exports.up = function (knex, Promise) {
   return knex.schema.createTable('ClaimExpense', function (table) {
     table.increments('ClaimExpenseId')
-    table.integer('EligibilityId').unsigned().notNullable().references('Claim.EligibilityId')
-    table.string('Reference', 10).notNullable().index().references('Claim.Reference')
+    table.integer('EligibilityId').unsigned().notNullable().references('Claim.EligibilityId') // REMOVED FOREIGN KEY IN LATER MIGRATION
+    table.string('Reference', 10).notNullable().index().references('Claim.Reference') // REMOVED FOREIGN KEY IN LATER MIGRATION
     table.integer('ClaimId').unsigned().notNullable().references('Claim.ClaimId')
     table.string('ExpenseType', 100).notNullable()
     table.decimal('Cost').notNullable()

--- a/migrations/20161112173325_add-claim-child.js
+++ b/migrations/20161112173325_add-claim-child.js
@@ -1,8 +1,8 @@
 exports.up = function (knex, Promise) {
   return knex.schema.createTable('ClaimChild', function (table) {
     table.increments('ClaimChildId')
-    table.integer('EligibilityId').unsigned().notNullable().references('Claim.EligibilityId')
-    table.string('Reference', 10).notNullable().index().references('Claim.Reference')
+    table.integer('EligibilityId').unsigned().notNullable().references('Claim.EligibilityId') // REMOVED FOREIGN KEY IN LATER MIGRATION
+    table.string('Reference', 10).notNullable().index().references('Claim.Reference') // REMOVED FOREIGN KEY IN LATER MIGRATION
     table.integer('ClaimId').unsigned().notNullable().references('Claim.ClaimId')
     table.string('FirstName', 50).notNullable()
     table.string('LastName', 50).notNullable()

--- a/migrations/20161221121204_add-claim-escort.js
+++ b/migrations/20161221121204_add-claim-escort.js
@@ -1,8 +1,8 @@
 exports.up = function (knex, Promise) {
   return knex.schema.createTable('ClaimEscort', function (table) {
     table.increments('ClaimEscortId')
-    table.integer('EligibilityId').unsigned().notNullable().references('Claim.EligibilityId')
-    table.string('Reference', 10).notNullable().index().references('Claim.Reference')
+    table.integer('EligibilityId').unsigned().notNullable().references('Claim.EligibilityId') // REMOVED FOREIGN KEY IN LATER MIGRATION
+    table.string('Reference', 10).notNullable().index().references('Claim.Reference') // REMOVED FOREIGN KEY IN LATER MIGRATION
     table.integer('ClaimId').unsigned().notNullable().references('Claim.ClaimId')
     table.string('FirstName', 100).notNullable()
     table.string('LastName', 100).notNullable()

--- a/migrations/20170120132709_drop-unique-on-claims-reference-and-eligibilityid-fields.js
+++ b/migrations/20170120132709_drop-unique-on-claims-reference-and-eligibilityid-fields.js
@@ -1,0 +1,57 @@
+exports.up = function (knex, Promise) {
+  return knex.schema.table('ClaimEscort', function (table) {
+    table.dropForeign('Reference')
+    table.dropForeign('EligibilityId')
+  })
+  .then(function () {
+    return knex.schema.table('ClaimChild', function (table) {
+      table.dropForeign('Reference')
+      table.dropForeign('EligibilityId')
+    })
+  })
+  .then(function () {
+    return knex.schema.table('ClaimExpense', function (table) {
+      table.dropForeign('Reference')
+      table.dropForeign('EligibilityId')
+    })
+  })
+  .then(function () {
+    return knex.schema.table('Claim', function (table) {
+      table.dropUnique('Reference')
+      table.dropUnique('EligibilityId')
+    })
+  })
+  .catch(function (error) {
+    console.log(error)
+    throw error
+  })
+}
+
+exports.down = function (knex, Promise) {
+  return knex.raw('ALTER TABLE Claim ADD CONSTRAINT claim_reference_unique UNIQUE NONCLUSTERED (Reference)')
+    .then(function () {
+      return knex.raw('ALTER TABLE Claim ADD CONSTRAINT claim_eligibilityid_unique UNIQUE NONCLUSTERED (EligibilityId)')
+    })
+    .then(function () {
+      return knex.schema.table('ClaimChild', function (table) {
+        table.foreign('Reference').references('Claim.Reference')
+        table.foreign('EligibilityId').references('Claim.EligibilityId')
+      })
+    })
+    .then(function () {
+      return knex.schema.table('ClaimExpense', function (table) {
+        table.foreign('Reference').references('Claim.Reference')
+        table.foreign('EligibilityId').references('Claim.EligibilityId')
+      })
+    })
+    .then(function () {
+      return knex.schema.table('ClaimEscort', function (table) {
+        table.foreign('Reference').references('Claim.Reference')
+        table.foreign('EligibilityId').references('Claim.EligibilityId')
+      })
+    })
+    .catch(function (error) {
+      console.log(error)
+      throw error
+    })
+}


### PR DESCRIPTION
Added migration to remove unique from reference and eligibilityId from claims to close #366 
This removes foreign keys from those that referenced these two fields
 
* Added migration 
* Added comments to state removal of foreign keys

## Checklist

- [x] Coding standards
- [x] Error Handling
