### PR TITLE
chore - allow sort codes with hyphens

### DIFF
--- a/app/services/domain/bank-account-details.js
+++ b/app/services/domain/bank-account-details.js
@@ -5,7 +5,7 @@ const ErrorHandler = require('../validators/error-handler')
 class BankAccountDetails {
   constructor (accountNumber, sortCode, termsAndConiditions) {
     this.accountNumber = accountNumber.replace(/ /g, '')
-    this.sortCode = sortCode.replace(/ /g, '')
+    this.sortCode = sortCode.replace(/ |-/g, '')
     this.termsAndConiditions = termsAndConiditions
     this.IsValid()
   }

--- a/test/unit/services/domain/test-bank-account-details.js
+++ b/test/unit/services/domain/test-bank-account-details.js
@@ -18,6 +18,26 @@ describe('services/domain/bank-account-details', function () {
     done()
   })
 
+  it('should construct a domain object given a sort code with hyphens', function (done) {
+    var sortCodeWithHyphens = '12-12-12'
+    var processedSortCodeWithHyphens = '121212'
+    bankAccountDetails = new BankAccountDetails(VALID_ACCOUNT_NUMBER, sortCodeWithHyphens, VALID_TERMS_AND_CONDITIONS)
+    expect(bankAccountDetails.accountNumber).to.equal(PROCESSED_ACCOUNT_NUMBER)
+    expect(bankAccountDetails.sortCode).to.equal(processedSortCodeWithHyphens)
+    expect(bankAccountDetails.termsAndConiditions).to.equal(VALID_TERMS_AND_CONDITIONS)
+    done()
+  })
+
+  it('should construct a domain object given a sort code with hyphens and spaces', function (done) {
+    var sortCodeWithHyphensAndSpaces = '12 - 12 - 12'
+    var processedSortCodeWithHyphensAndSpaces = '121212'
+    bankAccountDetails = new BankAccountDetails(VALID_ACCOUNT_NUMBER, sortCodeWithHyphensAndSpaces, VALID_TERMS_AND_CONDITIONS)
+    expect(bankAccountDetails.accountNumber).to.equal(PROCESSED_ACCOUNT_NUMBER)
+    expect(bankAccountDetails.sortCode).to.equal(processedSortCodeWithHyphensAndSpaces)
+    expect(bankAccountDetails.termsAndConiditions).to.equal(VALID_TERMS_AND_CONDITIONS)
+    done()
+  })
+
   it('should return isRequired errors given empty strings', function (done) {
     try {
       bankAccountDetails = new BankAccountDetails('', '', '')


### PR DESCRIPTION
chore - allow sort codes with hyphens

As per https://github.com/ministryofjustice/apvs-asynchronous-worker/issues/121

## Checklist

- [x] Unit tests
- [ ] End-to-End tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
