### PR TITLE
Age validation should now return error msg instead of redirect

### DIFF
--- a/app/routes/apply/new-eligibility/date-of-birth.js
+++ b/app/routes/apply/new-eligibility/date-of-birth.js
@@ -19,11 +19,7 @@ module.exports = function (router) {
         req.body['dob-year']
       )
 
-      if (dateOfBirth.sixteenOrUnder) {
-        return res.redirect('/eligibility-fail')
-      } else {
-        return res.redirect(`/apply/${req.params.claimType}/new-eligibility/${dateOfBirth.getDobFormatted}`)
-      }
+      return res.redirect(`/apply/${req.params.claimType}/new-eligibility/${dateOfBirth.getDobFormatted}`)
     } catch (error) {
       if (error instanceof ValidationError) {
         return res.status(400).render('apply/new-eligibility/date-of-birth', {

--- a/app/services/domain/date-of-birth.js
+++ b/app/services/domain/date-of-birth.js
@@ -1,6 +1,5 @@
 const ValidationError = require('../errors/validation-error')
 const FieldsetValidator = require('../validators/fieldset-validator')
-const commonValidator = require('../validators/common-validator')
 const ErrorHandler = require('../validators/error-handler')
 const dateFormatter = require('../date-formatter')
 const MINIMUM_AGE_IN_YEARS = 16
@@ -14,7 +13,6 @@ class DateOfBirth {
     ]
     this.dob = dateFormatter.build(day, month, year)
     this.getDobFormatted = dateFormatter.buildFormatted(day, month, year)
-    this.sixteenOrUnder = !commonValidator.isOlderThanInYears(this.dob, MINIMUM_AGE_IN_YEARS)
     this.IsValid()
   }
 
@@ -25,6 +23,7 @@ class DateOfBirth {
       .isRequired()
       .isValidDate(this.dob)
       .isPastDate(this.dob)
+      .isOlderThanInYears(this.dob, MINIMUM_AGE_IN_YEARS)
 
     var validationErrors = errors.get()
 

--- a/test/unit/routes/apply/new-eligibility/test-date-of-birth.js
+++ b/test/unit/routes/apply/new-eligibility/test-date-of-birth.js
@@ -77,15 +77,5 @@ describe('routes/apply/new-eligibility/date-of-birth', function () {
           .expect(500)
       })
     })
-
-    describe('sixteen or under date', function () {
-      it('should respond with a 302 and redirect to /eligibility-fail', function () {
-        stubDateOfBirth.returns({sixteenOrUnder: true})
-        return supertest(app)
-          .post(ROUTE)
-          .expect(302)
-          .expect('location', '/eligibility-fail')
-      })
-    })
   })
 })

--- a/test/unit/services/domain/test-date-of-birth.js
+++ b/test/unit/services/domain/test-date-of-birth.js
@@ -21,7 +21,6 @@ describe('services/domain/date-of-birth', function () {
 
     expect(dateOfBirth.dob.toString()).to.equal(dateFormatter.buildFromDateString(VALID_DOB).toString())
     expect(dateOfBirth.getDobFormatted).to.equal(dateFormatter.buildFromDateString(VALID_DOB).format('YYYY-MM-DD'))
-    expect(dateOfBirth.sixteenOrUnder).to.equal(false)
     expect(dateOfBirth.fields[0]).to.equal(VALID_DAY)
     expect(dateOfBirth.fields[1]).to.equal(VALID_MONTH)
     expect(dateOfBirth.fields[2]).to.equal(VALID_YEAR)
@@ -60,11 +59,14 @@ describe('services/domain/date-of-birth', function () {
     }
   })
 
-  it('should have sixteenOrUnder field set as true', function () {
-    dateOfBirth = new DateOfBirth(dateFormatter.now().date(),
-      dateFormatter.now().month() + 1,
-      dateFormatter.now().year())
-
-    expect(dateOfBirth.sixteenOrUnder).to.equal(true)
+  it('should return under 16 error message when date is < 16 years', function () {
+    try {
+      dateOfBirth = new DateOfBirth(dateFormatter.now().date(),
+        dateFormatter.now().month() + 1,
+        dateFormatter.now().year())
+    } catch (e) {
+      expect(e).to.be.instanceof(ValidationError)
+      expect(e.validationErrors['dob'][0]).to.equal('Must be over 16 years of age')
+    }
   })
 })


### PR DESCRIPTION
Modified DOB validation so that it returns an error message instead of redirecting to the eligibility-fail page.

Closes #370 