### PR TITLE
Increase ie8 e2e test timeout

### DIFF
--- a/test/wdio.conf.sauce.ie8.jenkins.js
+++ b/test/wdio.conf.sauce.ie8.jenkins.js
@@ -22,6 +22,6 @@ exports.config = {
   framework: 'mocha',
   mochaOpts: {
     ui: 'bdd',
-    timeout: 1000 * 60 * 5 // five minute per flow
+    timeout: 1000 * 60 * 8 // eight minutes per flow
   }
 }


### PR DESCRIPTION
This test was reaching its timeout intermittently, which was a few minutes lower than the other tests.

## Checklist

- [ ] Unit tests
- [ ] End-to-End tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
