### PR TITLE
Have test coverage ignore the data directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "gulp",
     "generate-assets": "gulp generate-assets",
     "test": "standard && mocha --recursive -u exports test/unit/",
-    "test-coverage": "istanbul cover _mocha -- --recursive -u exports test/unit/",
+    "test-coverage": "istanbul cover -x 'app/services/data/**' _mocha -- --recursive -u exports test/unit/",
     "test-unit": "mocha --recursive -u exports test/unit/",
     "test-integration": "mocha --recursive -u exports test/integration/ --timeout 5000",
     "test-e2e": "gulp --gulpfile gulpfile-e2e.js",


### PR DESCRIPTION
Have Istanbul (test coverage) ignore the data directory as we test via integration not unit tests. 

## Checklist

- [ ] Unit tests
- [ ] End-to-End tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
