### PR TITLE
Fixed issue where claim events intermittently doesn't display

### DIFF
--- a/app/views/partials/claim-summary/claim-summary-events.html
+++ b/app/views/partials/claim-summary/claim-summary-events.html
@@ -1,3 +1,4 @@
+{% if claimDetails.claimEvents.length > 0 %}
 <div class="form-group">
 
   <h1 class="heading-medium">Messages from caseworker</h1>
@@ -26,3 +27,6 @@
   </ul>
 
 </div>
+
+<br>
+{% endif %}

--- a/app/views/your-claims/view-claim.html
+++ b/app/views/your-claims/view-claim.html
@@ -38,13 +38,7 @@
 
   <br>
 
-  {% if claimDetails.claimEvents[0] %}
-
-    {% include "partials/claim-summary/claim-summary-events.html" %}
-
-    <br>
-
-  {% endif %}
+  {% include "partials/claim-summary/claim-summary-events.html" %}
 
   <form action="/your-claims/{{ dob }}/{{ encryptedReference }}/{{ claimId }}" method="post" class="form">
 


### PR DESCRIPTION
- Modified logic to show Rejected for advance claims with a status of rejected.
- Fixed issue where claim events don't always show in view-claim page.

See #401 for more info