### PR TITLE
Removed the  getDropboxIsRequired message

### DIFF
--- a/app/services/validators/field-validator.js
+++ b/app/services/validators/field-validator.js
@@ -22,8 +22,6 @@ class FieldValidator {
       } else {
         this.errors.add(this.fieldName, ERROR_MESSAGES.getIsRequired)
       }
-    } else if (this.data === 'select') {
-      this.errors.add(this.fieldName, ERROR_MESSAGES.getDropboxIsRequired)
     }
     return this
   }

--- a/app/services/validators/validation-error-messages.js
+++ b/app/services/validators/validation-error-messages.js
@@ -9,7 +9,6 @@ module.exports = {
   getInvalidDateFormatMessage: function (displayName) { return `${displayName} was invalid` },
   getFutureDateMessage: function (displayName) { return `${displayName} must be in the future` },
   getPastDateMessage: function (displayName) { return `${displayName} must be in the past` },
-  getDropboxIsRequired: function (displayName) { return `${displayName} is required` },
   getIsValidFormat: function (displayName) { return `${displayName} must have valid format` },
   getIsCurrency: function (displayName) { return `${displayName} must be a valid amount` },
   getIsGreaterThan: function (displayName) { return `${displayName} must be greater than zero` },


### PR DESCRIPTION
The getDropboxIsRequired message is not required as it simple copies the isRequired message. Removed it, and the code in the validator referring to it.

Brings code coverage up to 100%

## Checklist

- [x] Unit tests
- [ ] End-to-End tests
- [x] Code coverage checked
- [x] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
