### PR TITLE
Feature/apvs 1062/add relationship url enum

### DIFF
--- a/app/constants/benefits-enum.js
+++ b/app/constants/benefits-enum.js
@@ -65,6 +65,6 @@ module.exports = {
   },
 
   getByValue: function (value) {
-    return EnumHelper.getKeyByValue(this, value)
+    return EnumHelper.getKeyByAttribute(this, value)
   }
 }

--- a/app/constants/helpers/enum-helper.js
+++ b/app/constants/helpers/enum-helper.js
@@ -1,8 +1,11 @@
-module.exports.getKeyByValue = function (enumeration, value) {
+module.exports.getKeyByAttribute = function (enumeration, value, attribute) {
   var result = value
+  if (!attribute) {
+    attribute = 'value'
+  }
   Object.keys(enumeration).forEach(function (key) {
     var element = enumeration[key]
-    if (typeof element === 'object' && element.value === value) {
+    if (typeof element === 'object' && element[attribute] === value) {
       result = element
     }
   })

--- a/app/constants/helpers/prisons-helper.js
+++ b/app/constants/helpers/prisons-helper.js
@@ -2,6 +2,6 @@ const prisonsEnum = require('../prisons-enum')
 const enumHelper = require('./enum-helper')
 
 module.exports.isNorthernIrelandPrison = function (value) {
-  var prison = enumHelper.getKeyByValue(prisonsEnum, value)
+  var prison = enumHelper.getKeyByAttribute(prisonsEnum, value)
   return prison && prison.region === 'NI'
 }

--- a/app/constants/prisoner-relationships-enum.js
+++ b/app/constants/prisoner-relationships-enum.js
@@ -1,36 +1,43 @@
 module.exports = {
   HUSBAND_WIFE_CIVIL: {
     value: 'husband-wife-civil',
-    displayName: 'Husband, wife or civil partner'
+    displayName: 'Husband, wife or civil partner',
+    urlValue: 'r1'
   },
 
   PARTNER: {
     value: 'partner',
-    displayName: 'Partner'
+    displayName: 'Partner',
+    urlValue: 'r2'
   },
 
   PARENT_GRANDPARENT: {
     value: 'parent-grandparent',
-    displayName: 'Parent or grand-parent'
+    displayName: 'Parent or grand-parent',
+    urlValue: 'r3'
   },
 
   SIBLING: {
     value: 'sibling',
-    displayName: 'Brother or sister'
+    displayName: 'Brother or sister',
+    urlValue: 'r4'
   },
 
   CHILD: {
     value: 'child',
-    displayName: 'Son or daughter'
+    displayName: 'Son or daughter',
+    urlValue: 'r5'
   },
 
   SOLE_VISITOR: {
     value: 'sole-visitor',
-    displayName: 'Sole visitor'
+    displayName: 'Sole visitor',
+    urlValue: 'r6'
   },
 
   NONE: {
     value: 'none',
-    displayName: ''
+    displayName: '',
+    urlValue: 'r7'
   }
 }

--- a/app/routes/apply/new-eligibility/about-you.js
+++ b/app/routes/apply/new-eligibility/about-you.js
@@ -5,6 +5,8 @@ const referenceIdHelper = require('../../helpers/reference-id-helper')
 const insertVisitor = require('../../../services/data/insert-visitor')
 const getTravellingFromAndTo = require('../../../services/data/get-travelling-from-and-to')
 const prisonsHelper = require('../../../constants/helpers/prisons-helper')
+const enumHelper = require('../../../constants/helpers/enum-helper')
+const relationshipHelper = require('../../../constants/prisoner-relationships-enum')
 
 module.exports = function (router) {
   router.get('/apply/:claimType/new-eligibility/:dob/:relationship/:benefit/:referenceId', function (req, res) {
@@ -23,7 +25,7 @@ module.exports = function (router) {
     UrlPathValidator(req.params)
 
     var dob = req.params.dob
-    var relationship = req.params.relationship
+    var relationship = enumHelper.getKeyByAttribute(relationshipHelper, req.params.relationship, 'urlValue').value
     var benefit = req.params.benefit
     var referenceAndEligibilityId = referenceIdHelper.extractReferenceId(req.params.referenceId)
     var visitorDetails = req.body

--- a/app/routes/apply/new-eligibility/prisoner-relationship.js
+++ b/app/routes/apply/new-eligibility/prisoner-relationship.js
@@ -2,6 +2,7 @@ const PrisonerRelationship = require('../../../services/domain/prisoner-relation
 const UrlPathValidator = require('../../../services/validators/url-path-validator')
 const ValidationError = require('../../../services/errors/validation-error')
 const claimTypeEnum = require('../../../constants/claim-type-enum')
+const prisonerRelationshipEnum = require('../../../constants/prisoner-relationships-enum')
 
 module.exports = function (router) {
   router.get('/apply/:claimType/new-eligibility/:dob', function (req, res) {
@@ -20,7 +21,7 @@ module.exports = function (router) {
     try {
       var prisonerRelationship = new PrisonerRelationship(relationship)
 
-      if (prisonerRelationship.relationship === 'none') {
+      if (prisonerRelationship.relationship === prisonerRelationshipEnum.NONE.urlValue) {
         return res.redirect('/eligibility-fail')
       } else {
         var params = ''

--- a/app/services/data/disable-non-ticketed-expenses-for-claim.js
+++ b/app/services/data/disable-non-ticketed-expenses-for-claim.js
@@ -5,7 +5,7 @@ const knex = require('knex')(config)
 const Promise = require('bluebird')
 
 module.exports = function (reference, eligibilityId, claimId, expenseType) {
-  var expense = enumHelper.getKeyByValue(expenseTypeEnum, expenseType)
+  var expense = enumHelper.getKeyByAttribute(expenseTypeEnum, expenseType)
 
   if (expense && !expense.ticketed) {
     return knex('ClaimExpense').update('IsEnabled', false).where({'ClaimId': claimId, 'ExpenseType': expenseType})

--- a/app/services/validators/common-validator.js
+++ b/app/services/validators/common-validator.js
@@ -104,7 +104,7 @@ exports.isValidDateOfBirth = function (dob) {
 exports.isValidPrisonerRelationship = function (value) {
   var result = false
   Object.keys(prisonerRelationshipsEnum).forEach(function (key) {
-    if (key !== 'getByValue' && prisonerRelationshipsEnum[key].value === value) {
+    if (key !== 'getByValue' && prisonerRelationshipsEnum[key].urlValue === value) {
       result = true
     }
   })

--- a/app/views/apply/new-eligibility/prisoner-relationship.html
+++ b/app/views/apply/new-eligibility/prisoner-relationship.html
@@ -30,7 +30,7 @@
             <input id="husband-wife-civil"
                    type="radio"
                    name="relationship"
-                   value="husband-wife-civil">
+                   value="r1">
 
             <span class="heading-small">My husband, wife or civil partner</span>
             <br>
@@ -40,7 +40,7 @@
             <input id="partner"
                    type="radio"
                    name="relationship"
-                   value="partner">
+                   value="r2">
             <span class="heading-small">My partner</span>
             <br>
             You were living together as a couple before they went to prison or remand
@@ -50,7 +50,7 @@
             <input id="parent-grandparent"
                    type="radio"
                    name="relationship"
-                   value="parent-grandparent">
+                   value="r3">
             <span class="heading-small">My parent or grand-parent</span>
             <br>
             Includes step-parent or adoptive parent
@@ -60,7 +60,7 @@
             <input id="sibling"
                    type="radio"
                    name="relationship"
-                   value="sibling">
+                   value="r4">
             <span class="heading-small">My brother or sister</span>
             <br>
             Includes half-sibling, or step-sibling
@@ -70,7 +70,7 @@
             <input id="child"
                    type="radio"
                    name="relationship"
-                   value="child">
+                   value="r5">
             <span class="heading-small">My son or daughter</span>
             <br>
             Includes step- or adopted son or daughter
@@ -80,7 +80,7 @@
             <input id="sole-visitor"
                    type="radio"
                    name="relationship"
-                   value="sole-visitor">
+                   value="r6">
             <span class="heading-small">None of the above, but I am their only visitor for the next 4 weeks (sole visitor)</span>
             <br>
           </label>
@@ -89,7 +89,7 @@
             <input id="other"
                    type="radio"
                    name="relationship"
-                   value="none">
+                   value="r7">
             <span class="heading-small">None of the above</span>
             <br>
           </label>

--- a/app/views/helpers/display-helper.js
+++ b/app/views/helpers/display-helper.js
@@ -5,37 +5,37 @@ const expenseTypeEnum = require('../../constants/expense-type-enum')
 const enumHelper = require('../../constants/helpers/enum-helper')
 
 module.exports.getPrisonerRelationshipDisplayName = function (value) {
-  var element = enumHelper.getKeyByValue(prisonerRelationshipsEnum, value)
+  var element = enumHelper.getKeyByAttribute(prisonerRelationshipsEnum, value)
   return element.displayName
 }
 
 module.exports.getBenefitDisplayName = function (value) {
-  var element = enumHelper.getKeyByValue(benefitsEnum, value)
+  var element = enumHelper.getKeyByAttribute(benefitsEnum, value)
   return element.displayName
 }
 
 module.exports.getBenefitRequireUpload = function (value) {
-  var element = enumHelper.getKeyByValue(benefitsEnum, value)
+  var element = enumHelper.getKeyByAttribute(benefitsEnum, value)
   return element.requireBenefitUpload
 }
 
 module.exports.getBenefitMultipage = function (value) {
-  var element = enumHelper.getKeyByValue(benefitsEnum, value)
+  var element = enumHelper.getKeyByAttribute(benefitsEnum, value)
   return element.multipage
 }
 
 module.exports.getPrisonDisplayName = function (value) {
-  var element = enumHelper.getKeyByValue(prisonsEnum, value)
+  var element = enumHelper.getKeyByAttribute(prisonsEnum, value)
   return element.displayName
 }
 
 module.exports.getExpenseDisplayName = function (value) {
-  var element = enumHelper.getKeyByValue(expenseTypeEnum, value)
+  var element = enumHelper.getKeyByAttribute(expenseTypeEnum, value)
   return element.displayName
 }
 
 module.exports.getExpenseReceiptRequired = function (value) {
-  var element = enumHelper.getKeyByValue(expenseTypeEnum, value)
+  var element = enumHelper.getKeyByAttribute(expenseTypeEnum, value)
   return element.receiptRequired
 }
 

--- a/test/unit/constants/helpers/test-enum-helper.js
+++ b/test/unit/constants/helpers/test-enum-helper.js
@@ -6,19 +6,32 @@ const BenefitsEnum = require('../../../../app/constants/benefits-enum')
 describe('constants/helpers/enum-helper', function () {
   const VALID_VALUE = BenefitsEnum.INCOME_SUPPORT.value
   const INVALID_VALUE = 'some invalid value'
+  const VALID_DISPLAYNAME = BenefitsEnum.INCOME_SUPPORT.displayName
+  const VALID_ATTRIBUTE = 'displayName'
+  const INVALID_ATTRIBUTE = 'invalid'
 
-  it('should return the enumerated object whose value equals the value given', function () {
-    var result = EnumHelper.getKeyByValue(BenefitsEnum, VALID_VALUE)
+  it('should return the enumerated object whose value equals the value given and no attribute', function () {
+    var result = EnumHelper.getKeyByAttribute(BenefitsEnum, VALID_VALUE)
     expect(result).to.equal(BenefitsEnum.INCOME_SUPPORT)
   })
 
   it('should return the given value if no match was found.', function () {
-    var result = EnumHelper.getKeyByValue(BenefitsEnum, INVALID_VALUE)
+    var result = EnumHelper.getKeyByAttribute(BenefitsEnum, INVALID_VALUE)
     expect(result).to.equal(INVALID_VALUE)
   })
 
   it('should return the given value if the value given was not an object.', function () {
-    var result = EnumHelper.getKeyByValue(BenefitsEnum, null)
+    var result = EnumHelper.getKeyByAttribute(BenefitsEnum, null)
     expect(result).to.equal(null)
+  })
+
+  it('should return the correct value based on attribute.', function () {
+    var result = EnumHelper.getKeyByAttribute(BenefitsEnum, VALID_DISPLAYNAME, VALID_ATTRIBUTE)
+    expect(result).to.equal(BenefitsEnum.INCOME_SUPPORT)
+  })
+
+  it('should return the given value if no match was found for an invalid attribute.', function () {
+    var result = EnumHelper.getKeyByAttribute(BenefitsEnum, VALID_VALUE, INVALID_ATTRIBUTE)
+    expect(result).to.equal(VALID_VALUE)
   })
 })

--- a/test/unit/routes/apply/new-eligibility/test-about-the-prisoner.js
+++ b/test/unit/routes/apply/new-eligibility/test-about-the-prisoner.js
@@ -12,7 +12,7 @@ var stubInsertNewEligibilityAndPrisoner
 var app
 
 describe('routes/apply/new-eligibility/about-the-prisoner', function () {
-  const ROUTE = '/apply/first-time/new-eligibility/1980-01-01/partner/income-support'
+  const ROUTE = '/apply/first-time/new-eligibility/1980-01-01/r2/income-support'
 
   beforeEach(function () {
     urlPathValidatorStub = sinon.stub()

--- a/test/unit/routes/apply/new-eligibility/test-about-you.js
+++ b/test/unit/routes/apply/new-eligibility/test-about-you.js
@@ -13,7 +13,7 @@ var app
 
 describe('routes/apply/new-eligibility/about-you', function () {
   const REFERENCEID = 'ABOUTYO-1234'
-  const ROUTE = `/apply/first-time/new-eligibility/1980-01-01/partner/income-support/${REFERENCEID}`
+  const ROUTE = `/apply/first-time/new-eligibility/1980-01-01/r2/income-support/${REFERENCEID}`
 
   beforeEach(function () {
     urlPathValidatorStub = sinon.stub()

--- a/test/unit/routes/apply/new-eligibility/test-benefits.js
+++ b/test/unit/routes/apply/new-eligibility/test-benefits.js
@@ -10,7 +10,7 @@ const benefitsEnum = require('../../../../../app/constants/benefits-enum')
 
 describe('routes/apply/new-eligibility/benefits', function () {
   const DOB = '1988-05-15'
-  const RELATIONSHIP = prisonerRelationshipEnum.CHILD.value
+  const RELATIONSHIP = prisonerRelationshipEnum.CHILD.urlValue
   const ROUTE = `/apply/first-time/new-eligibility/${DOB}/${RELATIONSHIP}`
 
   var app

--- a/test/unit/routes/apply/new-eligibility/test-prisoner-relationship.js
+++ b/test/unit/routes/apply/new-eligibility/test-prisoner-relationship.js
@@ -44,8 +44,8 @@ describe('routes/apply/new-eligibility/prisoner-relationship', function () {
   })
 
   describe(`POST ${ROUTE}`, function () {
-    const VALID_RELATIONSHIP = prisonerRelationshipEnum.PARTNER.value
-    const INVALID_RELATIONSHIP = 'none'
+    const VALID_RELATIONSHIP = prisonerRelationshipEnum.PARTNER.urlValue
+    const INVALID_RELATIONSHIP = 'r7'
     const VALID_PRISONER_RELATIONSHIP = {
       relationship: VALID_RELATIONSHIP
     }

--- a/test/unit/services/domain/test-prisoner-relationship.js
+++ b/test/unit/services/domain/test-prisoner-relationship.js
@@ -4,7 +4,7 @@ const prisonerRelationshipEnum = require('../../../../app/constants/prisoner-rel
 const expect = require('chai').expect
 
 describe('services/domain/prisoner-relationship', function () {
-  const VALID_RELATIONSHIP = prisonerRelationshipEnum.PARTNER.value
+  const VALID_RELATIONSHIP = prisonerRelationshipEnum.PARTNER.urlValue
   const INVALID_RELATIONSHIP = ''
 
   it('should construct a domain object given valid input', function () {

--- a/test/unit/services/validators/test-common-validator.js
+++ b/test/unit/services/validators/test-common-validator.js
@@ -7,6 +7,7 @@ const booleanSelectEnum = require('../../../../app/constants/boolean-select-enum
 const advancePastEnum = require('../../../../app/constants/advance-past-enum')
 const claimTypeEnum = require('../../../../app/constants/claim-type-enum')
 const expenseTypeEnum = require('../../../../app/constants/expense-type-enum')
+const prisonerRelationshipsEnum = require('../../../../app/constants/prisoner-relationships-enum')
 
 describe('services/validators/common-validator', function () {
   const ALPHA_STRING = 'alpha'
@@ -604,7 +605,7 @@ describe('services/validators/common-validator', function () {
   })
 
   describe('isValidPrisonerRelationship', function () {
-    const VALID_INPUT = 'partner'
+    const VALID_INPUT = prisonerRelationshipsEnum.PARTNER.urlValue
     const INVALID_INPUT = 'some invalid input'
 
     it('should return false if passed null', function () {

--- a/test/unit/services/validators/test-field-validator.js
+++ b/test/unit/services/validators/test-field-validator.js
@@ -619,7 +619,7 @@ describe('services/validators/field-validator', function () {
   })
 
   describe('isValidPrisonerRelationship', function () {
-    const VALID_INPUT = prisonerRelationshipEnum.PARTNER.value
+    const VALID_INPUT = prisonerRelationshipEnum.PARTNER.urlValue
     const INVALID_INPUT = 'some invalid input'
 
     it('should return an error object if passed null', function () {

--- a/test/unit/services/validators/test-url-path-validator.js
+++ b/test/unit/services/validators/test-url-path-validator.js
@@ -12,7 +12,7 @@ describe('services/validators/url-path-validator', function () {
   const VALID_DOB = { dob: '1989-04-11' }
   const INVALID_DOB = { dob: 'invalid' }
 
-  const VALID_RELATIONSHIP = { relationship: prisonerRelationshipEnum.PARTNER.value }
+  const VALID_RELATIONSHIP = { relationship: prisonerRelationshipEnum.PARTNER.urlValue }
   const INVALID_RELATIONSHIP = { relationship: 'invalid' }
 
   const VALID_BENEFIT = { benefit: benefitsEnum.INCOME_SUPPORT.value }


### PR DESCRIPTION
Added to relationship enum to have a url value, also changed getKeyByValue to be getKeyByAttribute so it could be used for getting by urlValue as well. It defaults to most common usage of value if no attribute given.
 
* Added urlValue to prisoner relationships enum
* Changed getKeyByValue to getKeyByAttribute
* Updated html to have url values r1 - r7
* Updated routes, domains and validators to look for these values

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards