### PR TITLE
Chore/mask child on summary page

### DIFF
--- a/app/services/data/get-claim-summary.js
+++ b/app/services/data/get-claim-summary.js
@@ -3,6 +3,7 @@ const knex = require('knex')(config)
 const claimTypeEnum = require('../../constants/claim-type-enum')
 const documentTypeEnum = require('../../constants/document-type-enum')
 const getRepeatEligibility = require('./get-repeat-eligibility')
+const maskArrayOfNames = require('../helpers/mask-array-of-names')
 
 module.exports = function (claimId, claimType) {
   return knex('Claim')
@@ -86,9 +87,13 @@ module.exports = function (claimId, claimType) {
             .select()
             .orderBy('ClaimChild.FirstName')
             .then(function (claimChild) {
+              var child = claimChild
+              if (claimType === claimTypeEnum.REPEAT_DUPLICATE) {
+                child = maskArrayOfNames(claimChild)
+              }
               return {
                 claimExpenses: claimExpenses,
-                claimChild: claimChild
+                claimChild: child
               }
             })
         })

--- a/app/services/data/get-last-claim-details.js
+++ b/app/services/data/get-last-claim-details.js
@@ -1,18 +1,15 @@
 const getClaimChildrenByIdOrLastApproved = require('./get-claim-children-by-id-or-last-approved')
 const getClaimExpenseByIdOrLastApproved = require('./get-claim-expense-by-id-or-last-approved')
 const getClaimEscortByIdOrLastApproved = require('./get-claim-escort-by-id-or-last-approved')
-const maskString = require('../helpers/mask-string')
+const maskArrayOfNames = require('../helpers/mask-array-of-names')
 
-module.exports = function (reference, eligibilityId, maskChildName) {
+module.exports = function (reference, eligibilityId, mask) {
   var result = {}
 
   return getClaimChildrenByIdOrLastApproved(reference, eligibilityId, null)
     .then(function (lastClaimChildren) {
-      if (maskChildName) {
-        result.children = lastClaimChildren.map(function (claimChild) {
-          claimChild.LastName = maskString(claimChild.LastName, 1)
-          return claimChild
-        })
+      if (mask) {
+        result.children = maskArrayOfNames(lastClaimChildren)
       } else {
         result.children = lastClaimChildren
       }

--- a/app/services/helpers/mask-array-of-names.js
+++ b/app/services/helpers/mask-array-of-names.js
@@ -1,0 +1,8 @@
+const maskString = require('./mask-string')
+
+module.exports = function (array) {
+  return array.map(function (value) {
+    value.LastName = maskString(value.LastName, 1)
+    return value
+  })
+}

--- a/test/unit/services/data/test-get-last-claim-details.js
+++ b/test/unit/services/data/test-get-last-claim-details.js
@@ -20,13 +20,13 @@ const ESCORT = [{ClaimEscortId: 3}]
 var getClaimChildrenByIdOrLastApprovedStub = sinon.stub().resolves(CHILDREN)
 var getClaimExpenseByIdOrLastApprovedStub = sinon.stub().resolves(EXPENSES)
 var getClaimEscortByIdOrLastApprovedStub = sinon.stub().resolves(ESCORT)
-var maskStringStub = sinon.stub().returns(LAST_NAME_MASKED)
+var maskArrayOfNamesStub = sinon.stub().returns(LAST_NAME_MASKED)
 
 const getLastClaimDetails = proxyquire('../../../../app/services/data/get-last-claim-details', {
   './get-claim-children-by-id-or-last-approved': getClaimChildrenByIdOrLastApprovedStub,
   './get-claim-expense-by-id-or-last-approved': getClaimExpenseByIdOrLastApprovedStub,
   './get-claim-escort-by-id-or-last-approved': getClaimEscortByIdOrLastApprovedStub,
-  '../helpers/mask-string': maskStringStub
+  '../helpers/mask-array-of-names': maskArrayOfNamesStub
 })
 
 describe('services/data/get-last-claim-details', function () {
@@ -36,7 +36,7 @@ describe('services/data/get-last-claim-details', function () {
         sinon.assert.calledWith(getClaimChildrenByIdOrLastApprovedStub, REFERENCE, ELIGIBILITYID, null)
         sinon.assert.calledWith(getClaimExpenseByIdOrLastApprovedStub, REFERENCE, ELIGIBILITYID, null)
         sinon.assert.calledWith(getClaimEscortByIdOrLastApprovedStub, REFERENCE, ELIGIBILITYID, null)
-        sinon.assert.notCalled(maskStringStub)
+        sinon.assert.notCalled(maskArrayOfNamesStub)
 
         expect(result.children).to.be.equal(CHILDREN)
         expect(result.expenses).to.be.equal(EXPENSES)
@@ -50,7 +50,7 @@ describe('services/data/get-last-claim-details', function () {
         sinon.assert.calledWith(getClaimChildrenByIdOrLastApprovedStub, REFERENCE, ELIGIBILITYID, null)
         sinon.assert.calledWith(getClaimExpenseByIdOrLastApprovedStub, REFERENCE, ELIGIBILITYID, null)
         sinon.assert.calledWith(getClaimEscortByIdOrLastApprovedStub, REFERENCE, ELIGIBILITYID, null)
-        sinon.assert.calledWith(maskStringStub, LAST_NAME, 1)
+        sinon.assert.calledWith(maskArrayOfNamesStub, CHILDREN)
       })
   })
 })

--- a/test/unit/services/helpers/test-mask-array-of-names.js
+++ b/test/unit/services/helpers/test-mask-array-of-names.js
@@ -1,0 +1,21 @@
+const expect = require('chai').expect
+const maskArrayOfNames = require('../../../../app/services/helpers/mask-array-of-names')
+
+const LAST_NAME_1 = 'Bloggs'
+const LAST_NAME_MASKED_1 = 'B*****'
+
+const LAST_NAME_2 = 'Aloggs'
+const LAST_NAME_MASKED_2 = 'A*****'
+
+const NAMES = [
+  {LastName: LAST_NAME_1},
+  {LastName: LAST_NAME_2}
+]
+
+describe('services/helpers/mask-array-of-names', function () {
+  it('should return the masked array of input strings', function () {
+    var maskedArray = maskArrayOfNames(NAMES)
+    expect(maskedArray[0].LastName).to.equal(LAST_NAME_MASKED_1)
+    expect(maskedArray[1].LastName).to.equal(LAST_NAME_MASKED_2)
+  })
+})


### PR DESCRIPTION
Mask child name on claim summary relates to issue #464 
 
* Moved masking logic to own function
* Added function to claim summary

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards