### PR TITLE
Chore/fix upload repeat submission

### DIFF
--- a/app/services/data/disable-old-claim-documents.js
+++ b/app/services/data/disable-old-claim-documents.js
@@ -1,0 +1,23 @@
+const config = require('../../../knexfile').extweb
+const knex = require('knex')(config)
+const FileUpload = require('../domain/file-upload')
+const Promise = require('bluebird')
+
+module.exports = function (reference, claimId, claimExpenseId, fileUpload, multipageDoc) {
+  if (!(fileUpload instanceof FileUpload)) {
+    throw new Error('Provided fileUpload object is not an instance of the expected class')
+  }
+
+  if (multipageDoc) {
+    return Promise.resolve()
+  } else {
+    return knex('ClaimDocument')
+      .update('IsEnabled', false)
+      .where({
+        'Reference': reference,
+        'ClaimId': claimId,
+        'ClaimExpenseId': claimExpenseId,
+        'DocumentType': fileUpload.documentType
+      })
+  }
+}

--- a/app/services/data/disable-old-claim-documents.js
+++ b/app/services/data/disable-old-claim-documents.js
@@ -3,7 +3,7 @@ const knex = require('knex')(config)
 const FileUpload = require('../domain/file-upload')
 const Promise = require('bluebird')
 
-module.exports = function (reference, claimId, claimExpenseId, fileUpload, multipageDoc) {
+module.exports = function (reference, claimId, fileUpload, multipageDoc) {
   if (!(fileUpload instanceof FileUpload)) {
     throw new Error('Provided fileUpload object is not an instance of the expected class')
   }
@@ -16,7 +16,7 @@ module.exports = function (reference, claimId, claimExpenseId, fileUpload, multi
       .where({
         'Reference': reference,
         'ClaimId': claimId,
-        'ClaimExpenseId': claimExpenseId,
+        'ClaimExpenseId': fileUpload.claimExpenseId,
         'DocumentType': fileUpload.documentType
       })
   }

--- a/app/services/domain/file-upload.js
+++ b/app/services/domain/file-upload.js
@@ -19,6 +19,9 @@ class FileUpload {
     this.claimId = claimId
     this.documentType = documentTypeEnum[documentType].documentType
     this.claimExpenseId = claimExpenseId
+    if (this.claimExpenseId === undefined) {
+      this.claimExpenseId = null
+    }
     this.dateSubmitted = dateFormatter.now().toDate()
 
     if (file) {

--- a/test/integration/services/data/test-disable-old-claim-documents.js
+++ b/test/integration/services/data/test-disable-old-claim-documents.js
@@ -1,0 +1,54 @@
+const expect = require('chai').expect
+const eligiblityHelper = require('../../../helpers/data/eligibility-helper')
+const claimDocumentHelper = require('../../../helpers/data/claim-document-helper')
+const disableOldClaimDocuments = require('../../../../app/services/data/disable-old-claim-documents')
+
+describe('services/data/disable-non-ticketed-expenses-for-claim', function () {
+  const REFERENCE = 'DISDOCS'
+  const CLAIM_EXPENSE_ID = null
+  var eligibilityId
+  var claimId
+  var fileUpload
+
+  beforeEach(function () {
+    return eligiblityHelper.insertEligibilityClaim(REFERENCE)
+      .then(function (ids) {
+        eligibilityId = ids.eligibilityId
+        claimId = ids.claimId
+        fileUpload = claimDocumentHelper.build(claimId)
+        return claimDocumentHelper.insert(REFERENCE, eligibilityId, claimId, claimDocumentHelper.DOCUMENT_TYPE)
+      })
+  })
+
+  it('should disable previous documents if not a multipage document', function () {
+    var multipageDoc = false
+    return disableOldClaimDocuments(REFERENCE, claimId, CLAIM_EXPENSE_ID, fileUpload, multipageDoc)
+      .then(function () {
+        return claimDocumentHelper.get(claimId)
+      })
+      .then(function (claimDocument) {
+        expect(claimDocument.Reference).to.equal(REFERENCE)
+        expect(claimDocument.ClaimId).to.equal(claimId)
+        expect(claimDocument.DocumentType).to.equal(claimDocumentHelper.DOCUMENT_TYPE)
+        expect(claimDocument.IsEnabled).to.equal(false)
+      })
+  })
+
+  it('should not disable previous documents for multipage documents', function () {
+    var multipageDoc = true
+    return disableOldClaimDocuments(REFERENCE, claimId, CLAIM_EXPENSE_ID, fileUpload, multipageDoc)
+      .then(function () {
+        return claimDocumentHelper.get(claimId)
+      })
+      .then(function (claimDocument) {
+        expect(claimDocument.Reference).to.equal(REFERENCE)
+        expect(claimDocument.ClaimId).to.equal(claimId)
+        expect(claimDocument.DocumentType).to.equal(claimDocumentHelper.DOCUMENT_TYPE)
+        expect(claimDocument.IsEnabled).to.equal(true)
+      })
+  })
+
+  afterEach(function () {
+    return eligiblityHelper.deleteAll(REFERENCE)
+  })
+})

--- a/test/integration/services/data/test-disable-old-claim-documents.js
+++ b/test/integration/services/data/test-disable-old-claim-documents.js
@@ -5,7 +5,6 @@ const disableOldClaimDocuments = require('../../../../app/services/data/disable-
 
 describe('services/data/disable-non-ticketed-expenses-for-claim', function () {
   const REFERENCE = 'DISDOCS'
-  const CLAIM_EXPENSE_ID = null
   var eligibilityId
   var claimId
   var fileUpload
@@ -16,13 +15,14 @@ describe('services/data/disable-non-ticketed-expenses-for-claim', function () {
         eligibilityId = ids.eligibilityId
         claimId = ids.claimId
         fileUpload = claimDocumentHelper.build(claimId)
+        fileUpload.claimExpenseId = null
         return claimDocumentHelper.insert(REFERENCE, eligibilityId, claimId, claimDocumentHelper.DOCUMENT_TYPE)
       })
   })
 
   it('should disable previous documents if not a multipage document', function () {
     var multipageDoc = false
-    return disableOldClaimDocuments(REFERENCE, claimId, CLAIM_EXPENSE_ID, fileUpload, multipageDoc)
+    return disableOldClaimDocuments(REFERENCE, claimId, fileUpload, multipageDoc)
       .then(function () {
         return claimDocumentHelper.get(claimId)
       })
@@ -36,7 +36,7 @@ describe('services/data/disable-non-ticketed-expenses-for-claim', function () {
 
   it('should not disable previous documents for multipage documents', function () {
     var multipageDoc = true
-    return disableOldClaimDocuments(REFERENCE, claimId, CLAIM_EXPENSE_ID, fileUpload, multipageDoc)
+    return disableOldClaimDocuments(REFERENCE, claimId, fileUpload, multipageDoc)
       .then(function () {
         return claimDocumentHelper.get(claimId)
       })

--- a/test/unit/routes/apply/eligibility/claim/test-file-upload.js
+++ b/test/unit/routes/apply/eligibility/claim/test-file-upload.js
@@ -22,6 +22,7 @@ describe('routes/apply/eligibility/claim/file-upload', function () {
   var clamAvStub
   var configStub
   var insertTaskStub
+  var disableOldClaimDocumentsStub
 
   beforeEach(function () {
     urlPathValidatorStub = sinon.stub()
@@ -33,6 +34,7 @@ describe('routes/apply/eligibility/claim/file-upload', function () {
     clamAvStub = sinon.stub()
     configStub = sinon.stub()
     insertTaskStub = sinon.stub()
+    disableOldClaimDocumentsStub = sinon.stub().resolves()
 
     var route = proxyquire('../../../../../../app/routes/apply/eligibility/claim/file-upload', {
       '../../../../services/validators/url-path-validator': urlPathValidatorStub,
@@ -44,6 +46,7 @@ describe('routes/apply/eligibility/claim/file-upload', function () {
       '../../../../services/clam-av': { clamAvStub, '@noCallThru': true },
       '../../../../../config': configStub,
       '../../../../services/data/insert-task': insertTaskStub,
+      '../../../../services/data/disable-old-claim-documents': disableOldClaimDocumentsStub,
       'csurf': function () { return function () { } }
     })
     app = routeHelper.buildApp(route)

--- a/test/unit/services/domain/test-file-upload.js
+++ b/test/unit/services/domain/test-file-upload.js
@@ -41,11 +41,11 @@ describe('services/domain/file-upload', function () {
     expect(fileUpload.documentStatus).to.equal(VALID_DOCUMENT_STATUS)
   })
 
-  it('should construct a domain object given valid input when documentStatus is set to alternative', function () {
+  it('should construct a domain object given valid input when documentStatus is set to alternative and change undefined claimExpeneseId to null', function () {
     var fileUpload = new FileUpload(
       VALID_ID,
       VALID_DOCUMENT_TYPE,
-      VALID_ID,
+      undefined,
       undefined,
       undefined,
       VALID_ALTERNATIVE
@@ -53,6 +53,7 @@ describe('services/domain/file-upload', function () {
 
     expect(fileUpload.path).to.equal(undefined)
     expect(fileUpload.claimId).to.equal(VALID_ID)
+    expect(fileUpload.claimExpenseId).to.equal(null)
     expect(fileUpload.documentStatus).to.equal(VALID_ALTERNATIVE)
   })
 


### PR DESCRIPTION
Added a disable call to disable all old documents on file upload unless it is part of a multipage document. Relates to issue #439 
 
* Added disable old documents
* Added this to file upload route
* Updated file upload domain to explicitly make undefined claimExpenseIds null

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards