### PR TITLE
Changed change to be link rather than post to remove

### DIFF
--- a/app/views/partials/claim-summary/claim-summary-expenses.html
+++ b/app/views/partials/claim-summary/claim-summary-expenses.html
@@ -94,21 +94,11 @@
 
         {% elif claimExpense.DocumentStatus == 'upload-later' %}
           <span class="text-pending">Uploading receipt later</span>
-          <form
-            action="{{ URL }}/remove-document/{{ claimExpense.ClaimDocumentId }}?document=RECEIPT&claimExpenseId={{ claimExpense.ClaimExpenseId }}&eligibilityId={{ claimDetails.claim.EligibilityId }}"
-            method="post" class="form pull-right">
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-            <button class="link" name="change">change</button>
-          </form>
+          <a href="{{ URL }}/file-upload?document=RECEIPT&claimExpenseId={{ claimExpense.ClaimExpenseId }}&eligibilityId={{ claimDetails.claim.EligibilityId }}" class="link pull-right" name="change" id="change-receipt-post">change</button>
 
         {% elif claimExpense.DocumentStatus == 'post-later' %}
           <span class="text-pending">Sending receipt by post</span>
-          <form
-            action="{{ URL }}/remove-document/{{ claimExpense.ClaimDocumentId }}?document=RECEIPT&claimExpenseId={{ claimExpense.ClaimExpenseId }}&eligibilityId={{ claimDetails.claim.EligibilityId }}"
-            method="post" class="form pull-right">
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-            <button class="link" name="change">change</button>
-          </form>
+          <a href="{{ URL }}/file-upload?document=RECEIPT&claimExpenseId={{ claimExpense.ClaimExpenseId }}&eligibilityId={{ claimDetails.claim.EligibilityId }}" class="link pull-right" name="change" id="change-receipt-post">change</button>
 
         {% else %}
           <span class="text-warning">Receipt needed</span>

--- a/app/views/partials/claim-summary/claim-summary-visit.html
+++ b/app/views/partials/claim-summary/claim-summary-visit.html
@@ -84,20 +84,10 @@
             </form>
           {% elif claimDetails.claim.visitConfirmation['DocumentStatus'] == 'upload-later' %}
             <span class="text-pending">Uploading visit confirmation later</span>
-            <form
-              action="{{ URL }}/remove-document/{{ claimDetails.claim.visitConfirmation.ClaimDocumentId }}?document=VISIT_CONFIRMATION&eligibilityId={{ claimDetails.claim.EligibilityId }}"
-              method="post" class="form pull-right">
-              <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-              <button class="link" name="change" id="change-visit-confirmation-upload-later">change</button>
-            </form>
+            <a href="{{ URL }}/file-upload?document=VISIT_CONFIRMATION&eligibilityId={{ claimDetails.claim.EligibilityId }}" class="link pull-right" name="change" id="change-visit-confirmation-post">change</a>
           {% elif claimDetails.claim.visitConfirmation['DocumentStatus'] == 'post-later' %}
             <span class="text-pending">Sending visit confirmation by post</span>
-            <form
-              action="{{ URL }}/remove-document/{{ claimDetails.claim.visitConfirmation.ClaimDocumentId }}?document=VISIT_CONFIRMATION&eligibilityId={{ claimDetails.claim.EligibilityId }}"
-              method="post" class="form pull-right">
-              <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-              <button class="link" name="change" id="change-visit-confirmation-post">change</button>
-            </form>
+            <a href="{{ URL }}/file-upload?document=VISIT_CONFIRMATION&eligibilityId={{ claimDetails.claim.EligibilityId }}" class="link pull-right" name="change" id="change-visit-confirmation-post">change</a>
           {% else %}
             <span class="text-warning">Visit confirmation needed</span>
             <a href="{{ URL }}/file-upload?document=VISIT_CONFIRMATION&eligibilityId={{ claimDetails.claim.EligibilityId }}" id="add-visit-confirmation" class="button grey pull-right">Add</a>

--- a/app/views/partials/claim-summary/claim-summary-visitor.html
+++ b/app/views/partials/claim-summary/claim-summary-visitor.html
@@ -88,20 +88,10 @@
             {% endif %}
           {% elif claimDetails.claim['benefitDocument'][0]['DocumentStatus'] == 'upload-later' %}
             <span class="text-pending">Uploading benefit documentation later</span>
-            <form
-              action="{{ URL }}/remove-document/{{ claimDetails.claim.benefitDocument[0].ClaimDocumentId }}?document={{ claimDetails.claim['Benefit'] }}&eligibilityId={{ claimDetails.claim.EligibilityId }}"
-              method="post" class="form pull-right">
-              <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-              <button class="link" name="change" id="change-{{ claimDetails.claim['Benefit'] }}-upload-later">change</button>
-            </form>
+            <a href="{{ URL }}/file-upload?document={{ claimDetails.claim['Benefit'] }}&eligibilityId={{ claimDetails.claim.EligibilityId }}" class="link pull-right" name="change" id="change-benefit-documentation-post">change</a>
           {% elif claimDetails.claim['benefitDocument'][0]['DocumentStatus'] == 'post-later' %}
             <span class="text-pending">Sending benefit documentation by post</span>
-            <form
-              action="{{ URL }}/remove-document/{{ claimDetails.claim.benefitDocument[0].ClaimDocumentId }}?document={{ claimDetails.claim['Benefit'] }}&eligibilityId={{ claimDetails.claim.EligibilityId }}"
-              method="post" class="form pull-right">
-              <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-              <button class="link" name="change" id="change-{{ claimDetails.claim['Benefit'] }}-post">change</button>
-            </form>
+            <a href="{{ URL }}/file-upload?document={{ claimDetails.claim['Benefit'] }}&eligibilityId={{ claimDetails.claim.EligibilityId }}" class="link pull-right" name="change" id="change-benefit-documentation-post">change</a>
           {% elif benefitUploadNotRequired %}
             <span class="text-success">Benefit document previously uploaded</span>
           {% else %}


### PR DESCRIPTION
Since there is a back button and now old claim documents are removed if they exist when posting, change was still removing the document. Now it is just a link
