### PR TITLE
Feature/apvs 1426/submitting twice when finishing claim

### DIFF
--- a/app/services/data/check-status-for-finishing-claim.js
+++ b/app/services/data/check-status-for-finishing-claim.js
@@ -1,0 +1,15 @@
+const config = require('../../../knexfile').extweb
+const knex = require('knex')(config)
+const claimStatusEnum = require('../../constants/claim-status-enum')
+
+module.exports = function (reference, eligibilityId, claimId) {
+  return knex('Claim')
+    .where({'Reference': reference, 'EligibilityId': eligibilityId, 'ClaimId': claimId, 'Status': claimStatusEnum.IN_PROGRESS})
+    .first('ClaimId')
+    .then(function (claimId) {
+      if (!claimId) {
+        return false
+      }
+      return true
+    })
+}

--- a/config.js
+++ b/config.js
@@ -46,5 +46,5 @@ module.exports = {
   MALWARE_NOTIFICATION_EMAIL_ADDRESS: process.env.APVS_MALWARE_NOTIFICATION_ADDRESS || 'donotsend@apvs.com',
 
   // Payout feature toggle
-  PAYOUT_FEATURE_TOGGLE: process.env.APVS_PAYOUT_FEATURE_TOGGLE || 'false'
+  PAYOUT_FEATURE_TOGGLE: process.env.APVS_PAYOUT_FEATURE_TOGGLE || 'true'
 }

--- a/test/integration/services/data/test-check-status-for-finishing-claim.js
+++ b/test/integration/services/data/test-check-status-for-finishing-claim.js
@@ -1,0 +1,40 @@
+const expect = require('chai').expect
+const checkStatusForFinishingClaim = require('../../../../app/services/data/check-status-for-finishing-claim')
+const eligibilityHelper = require('../../../helpers/data/eligibility-helper')
+const config = require('../../../../knexfile').extweb
+const knex = require('knex')(config)
+
+describe('services/data/check-status-for-finishing-claim', function () {
+  const REFERENCE = 'FINSTAT'
+  var claimId
+  var eligibilityId
+
+  beforeEach(function () {
+    return eligibilityHelper.insertEligibilityClaim(REFERENCE)
+      .then(function (ids) {
+        claimId = ids.claimId
+        eligibilityId = ids.eligibilityId
+      })
+  })
+
+  afterEach(function () {
+    return eligibilityHelper.deleteAll(REFERENCE)
+  })
+
+  it('should return true for claim that is in progress', function () {
+    return checkStatusForFinishingClaim(REFERENCE, eligibilityId, claimId)
+      .then(function (result) {
+        expect(result).to.be.true
+      })
+  })
+
+  it('should return false claim not being in progress', function () {
+    return knex('Claim').update({'Status': 'NOT-IN-PROGRESS'}).where({'ClaimId': claimId, 'Reference': REFERENCE})
+      .then(function () {
+        return checkStatusForFinishingClaim(REFERENCE, eligibilityId, claimId)
+          .then(function (result) {
+            expect(result).to.be.false
+          })
+      })
+  })
+})


### PR DESCRIPTION
Add logic to handle double submission on the payment details page
 
* Added DB check of claim current status
* Added logic in route to assume claim already submitted to prevent double submission attempt

## Checklist

- [x] Unit tests
- [x] Code coverage checked
- [x] Coding standards