### PR TITLE
Changed check from time based to date based

### DIFF
--- a/test/integration/services/data/test-get-claim-summary.js
+++ b/test/integration/services/data/test-get-claim-summary.js
@@ -9,6 +9,7 @@ const claimTypeEnum = require('../../../../app/constants/claim-type-enum')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 require('sinon-bluebird')
+const moment = require('moment')
 
 const MASKED_ELIGIBILITY = {LastName: 'MASKED_LAST_NAME'}
 const getRepeatEligibilityStub = sinon.stub().resolves(MASKED_ELIGIBILITY)
@@ -42,10 +43,7 @@ describe('services/data/get-claim-summary', function () {
       return getClaimSummary(claimId, claimTypeEnum.FIRST_TIME)
         .then(function (result) {
           expect(result.claim.Reference).to.equal(REFERENCE)
-          expect(result.claim.DateOfJourney).to.be.within(
-            claimHelper.DATE_OF_JOURNEY.subtract(1, 'seconds').toDate(),
-            claimHelper.DATE_OF_JOURNEY.add(1, 'seconds').toDate()
-          )
+          expect(moment(result.claim.DateOfJourney).format('DD/MM/YYYY')).to.equal(claimHelper.DATE_OF_JOURNEY.format('DD/MM/YYYY'))
           expect(result.claim.IsAdvanceClaim).to.equal(false)
           expect(result.claim.visitConfirmation.DocumentStatus).to.equal(claimDocumentHelper.DOCUMENT_STATUS)
           expect(result.claim.benefitDocument[0].DocumentStatus).to.equal(claimDocumentHelper.DOCUMENT_STATUS)

--- a/test/integration/services/data/test-insert-new-claim.js
+++ b/test/integration/services/data/test-insert-new-claim.js
@@ -2,6 +2,7 @@ const expect = require('chai').expect
 const insertNewClaim = require('../../../../app/services/data/insert-new-claim')
 const eligiblityHelper = require('../../../helpers/data/eligibility-helper')
 const claimHelper = require('../../../helpers/data/claim-helper')
+const moment = require('moment')
 
 describe('services/data/insert-new-claim', function () {
   const REFERENCE = 'APVS137'
@@ -27,10 +28,7 @@ describe('services/data/insert-new-claim', function () {
         expect(claim.Reference).to.be.equal(REFERENCE)
         expect(claim.ClaimType).to.be.equal(CLAIM_TYPE)
         expect(claim.IsAdvanceClaim).to.be.equal(claimHelper.IS_ADVANCE_CLAIM)
-        expect(claim.DateOfJourney).to.be.within(
-          claimHelper.DATE_OF_JOURNEY.subtract(1, 'seconds').toDate(),
-          claimHelper.DATE_OF_JOURNEY.add(1, 'seconds').toDate()
-        )
+        expect(moment(claim.DateOfJourney).format('DD/MM/YYYY')).to.equal(claimHelper.DATE_OF_JOURNEY.format('DD/MM/YYYY'))
         expect(claim.DateSubmitted).to.be.equal(null)
         expect(claim.Status).to.equal(claimHelper.STATUS)
       })


### PR DESCRIPTION
Due to DST the check for Date of Journey was failing on insert and claim summary - so changed to just check the date not the time