### PR TITLE
Issue/benefits back button

### DIFF
--- a/app/constants/benefits-enum.js
+++ b/app/constants/benefits-enum.js
@@ -73,6 +73,14 @@ module.exports = {
     urlValue: 'b9'
   },
 
+  NONE: {
+    value: 'none',
+    requireBenefitUpload: false,
+    displayName: 'None',
+    multipage: false,
+    urlValue: 'none'
+  },
+
   getByValue: function (value) {
     return EnumHelper.getKeyByAttribute(this, value)
   }

--- a/test/unit/services/validators/test-field-validator.js
+++ b/test/unit/services/validators/test-field-validator.js
@@ -739,13 +739,13 @@ describe('services/validators/field-validator', function () {
       expect(errors).to.equal(false)
     })
 
-    it('should return an error object if passed none and fromDomain is false', function () {
+    it('should return not return an error object if passed none and fromDomain is false', function () {
       var errorHandler = ErrorHandler()
       var fromDomain = false
-      FieldValidator(NONE_OF_THE_ABOVE, FIELD_NAME, errorHandler)
+      FieldValidator(NONE_OF_THE_ABOVE, 'None', errorHandler)
         .isValidBenefit(fromDomain)
       var errors = errorHandler.get()
-      expect(errors).to.have.property(FIELD_NAME)
+      expect(errors).to.equal(false)
     })
 
     it('should return an error object if passed an invalid benefits value', function () {


### PR DESCRIPTION
This fixes the back button issue identified during exploratory testing in response to the file upload issue:

1. Navigate to benefit select page of the first time claim process
2. Select 'None of the above' and proceed to the eligibility fail page
3. Navigate back using the browser's back button
4. Error is diplayed

The error results from a missing value for the None option in the enumeration backing this radio button set. This fix applies the missing value and updates tests accordingly.

## Checklist

- [X] Unit tests
- [X] End-to-End tests
- [X] Code coverage checked
- [X] Coding standards
- [X] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [X] README updated
