### PR TITLE
Feature/apvs 0050/help new fields

### DIFF
--- a/app/routes/technical-help.js
+++ b/app/routes/technical-help.js
@@ -21,7 +21,9 @@ module.exports = function (router) {
         req.body.issue
       )
 
-      insertTask(null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${technicalHelp.name}~~${technicalHelp.emailAddress}~~Reference number: ${technicalHelp.referenceNumber}\n\nDate of Claim: ${technicalHelp.dateOfClaim.format('DD-MM-YYYY')}\n\n${technicalHelp.issue}`)
+      var formattedDate = technicalHelp.dateOfClaim ? `${req.body['date-of-claim-day']}-${req.body['date-of-claim-month']}-${req.body['date-of-claim-year']}` : ''
+
+      insertTask(null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${technicalHelp.name}~~${technicalHelp.emailAddress}~~Reference number: ${technicalHelp.referenceNumber}\n\nDate of Claim: ${formattedDate}\n\n${technicalHelp.issue}`)
         .then(function () {
           return res.redirect('/')
         })

--- a/app/routes/technical-help.js
+++ b/app/routes/technical-help.js
@@ -11,8 +11,17 @@ module.exports = function (router) {
 
   router.post('/help', function (req, res, next) {
     try {
-      var technicalHelp = new TechnicalHelp(req.body.name, req.body.emailAddress, req.body.issue)
-      insertTask(null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${technicalHelp.name}~~${technicalHelp.emailAddress}~~${technicalHelp.issue}`)
+      var technicalHelp = new TechnicalHelp(
+        req.body.name,
+        req.body.emailAddress,
+        req.body.referenceNumber,
+        req.body['date-of-claim-day'],
+        req.body['date-of-claim-month'],
+        req.body['date-of-claim-year'],
+        req.body.issue
+      )
+
+      insertTask(null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${technicalHelp.name}~~${technicalHelp.emailAddress}~~${technicalHelp.referenceNumber}~~${technicalHelp.dateOfClaim}~~${technicalHelp.issue}`)
         .then(function () {
           return res.redirect('/')
         })
@@ -21,7 +30,15 @@ module.exports = function (router) {
         return res.status(400).render('technical-help', {
           errors: error.validationErrors,
           rating: req.body.rating,
-          help: {name: req.body.name, emailAddress: req.body.emailAddress, issue: req.body.issue}
+          help: {
+            name: req.body.name,
+            emailAddress: req.body.emailAddress,
+            referenceNumber: req.body.referenceNumber,
+            'date-of-claim-day': req.body['date-of-claim-day'],
+            'date-of-claim-month': req.body['date-of-claim-month'],
+            'date-of-claim-year': req.body['date-of-claim-year'],
+            issue: req.body.issue
+          }
         })
       } else {
         next(error)

--- a/app/routes/technical-help.js
+++ b/app/routes/technical-help.js
@@ -21,7 +21,7 @@ module.exports = function (router) {
         req.body.issue
       )
 
-      insertTask(null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${technicalHelp.name}~~${technicalHelp.emailAddress}~~${technicalHelp.referenceNumber}~~${technicalHelp.dateOfClaim}~~${technicalHelp.issue}`)
+      insertTask(null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${technicalHelp.name}~~${technicalHelp.emailAddress}~~Reference number: ${technicalHelp.referenceNumber}\n\nDate of Claim: ${technicalHelp.dateOfClaim.format('DD-MM-YYYY')}\n\n${technicalHelp.issue}`)
         .then(function () {
           return res.redirect('/')
         })

--- a/app/services/domain/technical-help.js
+++ b/app/services/domain/technical-help.js
@@ -1,12 +1,16 @@
 const ValidationError = require('../errors/validation-error')
 const FieldValidator = require('../validators/field-validator')
+const FieldsetValidator = require('../validators/fieldset-validator')
 const ErrorHandler = require('../validators/error-handler')
 const ERROR_MESSAGES = require('../validators/validation-error-messages')
+const dateFormatter = require('../date-formatter')
 
 class Feedback {
-  constructor (name, emailAddress, issue) {
+  constructor (name, emailAddress, referenceNumber, day, month, year, issue) {
     this.name = name ? name.trim() : ''
     this.emailAddress = emailAddress ? emailAddress.trim() : ''
+    this.referenceNumber = referenceNumber ? referenceNumber.trim() : ''
+    this.dateOfClaim = day || month || year ? dateFormatter.build(day, month, year) : ''
     this.issue = issue
     this.isValid()
   }
@@ -22,6 +26,13 @@ class Feedback {
       .isRequired(ERROR_MESSAGES.getEnterYourEmailAddress)
       .isLessThanLength(100)
       .isEmail()
+
+    FieldValidator(this.referenceNumber, 'ReferenceNumber', errors)
+      .isLessThanLength(100)
+      .isEmptyOrReference()
+
+    FieldsetValidator(this.dateOfClaim, 'DateOfClaim', errors)
+      .isEmptyOrValidDate(this.dateOfClaim)
 
     FieldValidator(this.issue, 'issue', errors)
       .isRequired()

--- a/app/services/validators/field-validator.js
+++ b/app/services/validators/field-validator.js
@@ -104,6 +104,13 @@ class FieldValidator {
     return this
   }
 
+  isEmptyOrReference () {
+    if (!validator.isNullOrUndefined(this.data) && !validator.isValidReference(this.data)) {
+      this.errors.add(this.fieldName, ERROR_MESSAGES.getIsValidReference)
+    }
+    return this
+  }
+
   isValidChildRelationship () {
     if (!validator.isValidChildRelationship(this.data)) {
       this.errors.add(this.fieldName, ERROR_MESSAGES.getIsValidOption)

--- a/app/services/validators/fieldset-validator.js
+++ b/app/services/validators/fieldset-validator.js
@@ -28,7 +28,7 @@ class FieldsetValidator {
     return this
   }
 
-  isEmptyOrValidDate(date) {
+  isEmptyOrValidDate (date) {
     if (!validator.isNullOrUndefined(date) && !validator.isValidDate(date)) {
       this.errors.add(this.fieldName, ERROR_MESSAGES.getInvalidDateFormatMessage)
     }

--- a/app/services/validators/fieldset-validator.js
+++ b/app/services/validators/fieldset-validator.js
@@ -28,6 +28,13 @@ class FieldsetValidator {
     return this
   }
 
+  isEmptyOrValidDate(date) {
+    if (!validator.isNullOrUndefined(date) && !validator.isValidDate(date)) {
+      this.errors.add(this.fieldName, ERROR_MESSAGES.getInvalidDateFormatMessage)
+    }
+    return this
+  }
+
   isValidDate (date) {
     if (!validator.isValidDate(date)) {
       this.errors.add(this.fieldName, ERROR_MESSAGES.getInvalidDateFormatMessage)

--- a/app/services/validators/validation-field-names.js
+++ b/app/services/validators/validation-field-names.js
@@ -54,5 +54,6 @@ module.exports = {
   'advance-past': 'response',
   'departure-time': 'Departure time',
   'return-time': 'Return time',
-  'PaymentMethod': 'Payment method'
+  'PaymentMethod': 'Payment method',
+  'DateOfClaim': 'Date of claim'
 }

--- a/app/views/technical-help.html
+++ b/app/views/technical-help.html
@@ -17,7 +17,7 @@ Ask for help - {{ serviceName }}
 
       <h1 class="heading-xlarge">Ask for help</h1>
 
-      <p>Enter your name, email address and a brief description of what you need help with. We'll get back to you within two working days.</p>
+      <p>Enter your name, email address and a brief description of what you need help with. The Assisted Prison Visits Unit will respond as soon as possible.</p>
       <p>We’ll only use your details to call you back. Don’t include any personal information, for example address or date of birth.</p>
 
       <form action="/help" method="post">
@@ -35,6 +35,55 @@ Ask for help - {{ serviceName }}
             <span class="error-message" id="error-message-email-address">{{ errors['EmailAddress'][0] }}</span>
           {% endif %}
           <input id="EmailAddress" autocomplete="off" name="emailAddress" class="form-control" value="{{ help['emailAddress'] }}">
+        </div>
+
+        <div class="form-group {% if errors['ReferenceNumber'][0] %} error {% endif %}">
+          <label for="referenceNumber" class="form-label-bold">Reference Number (optional)</label>
+          {% if errors['Reference Number'][0] %}
+            <span class="error-message" id="error-message-reference-number">{{ errors['ReferenceNumber'][0] }}</span>
+          {% endif %}
+          <input id="ReferenceNumber" autocomplete="off" name="referenceNumber" class="form-control" value="{{ help['referenceNumber'] }}">
+        </div>
+
+        <div class="form-group {% if errors['DateOfClaim'][0] %} error {% endif %}">
+          <fieldset>
+            <legend class="hidden">Date of claim</legend>
+            <div id="date-of-claim" class="form-date">
+              <label class="form-label-bold">Date of claim (optional)</label>
+
+              {% if errors['DateOfClaim'][0] %}
+                <span class="error-message">{{ errors['DateOfClaim'][0] }}</span>
+              {% endif %}
+
+              <div class="form-group form-group-day">
+                <label id="date-of-claim-day" for="date-of-claim-day-input">Day</label>
+                <input id="date-of-claim-day-input"
+                        type="number"
+                        name="date-of-claim-day"
+                        autocomplete="off"
+                        value="{{ help['date-of-claim-day'] }}"
+                        class="form-control"/>
+              </div>
+              <div class="form-group form-group-month">
+                <label id="date-of-claim-month" for="date-of-claim-month-input">Month</label>
+                <input id="date-of-claim-month-input"
+                        type="number"
+                        name="date-of-claim-month"
+                        autocomplete="off"
+                        value="{{ help['date-of-claim-month'] }}"
+                        class="form-control"/>
+              </div>
+              <div class="form-group form-group-year">
+                <label id="date-of-claim-year" for="date-of-claim-year-input">Year</label>
+                <input id="date-of-claim-year-input"
+                        type="number"
+                        name="date-of-claim-year"
+                        autocomplete="off"
+                        value="{{ help['date-of-claim-year'] }}"
+                        class="form-control"/>
+              </div>
+            </div>
+          </fieldset>
         </div>
 
         <p id="issue" class="heading-small">Describe what you'd like to talk about</p>

--- a/test/unit/routes/test-technical-help.js
+++ b/test/unit/routes/test-technical-help.js
@@ -13,13 +13,13 @@ describe('routes/help', function () {
     name: 'Joe Bloggs',
     emailAddress: 'test@test.com',
     referenceNumber: '',
-    'date-of-claim-day': undefined,
-    'date-of-claim-month': undefined,
-    'date-of-claim-year': undefined,
+    'date-of-claim-day': '',
+    'date-of-claim-month': '',
+    'date-of-claim-year': '',
     issue: 'Testing problems are occuring'
   }
 
-  var dateOfClaim = undefined
+  var dateOfClaim
   var app
 
   var technicalHelpStub
@@ -53,7 +53,7 @@ describe('routes/help', function () {
         .expect(302)
         .expect(function () {
           sinon.assert.calledWith(technicalHelpStub, VALID_DATA.name, VALID_DATA.emailAddress, VALID_DATA.referenceNumber, VALID_DATA.day, VALID_DATA.month, VALID_DATA.year, VALID_DATA.issue)
-          sinon.assert.calledWith(insertTaskStub, null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${VALID_DATA.name}~~${VALID_DATA.emailAddress}~~${VALID_DATA.referenceNumber}~~${dateOfClaim}~~${VALID_DATA.issue}`)
+          sinon.assert.calledWith(insertTaskStub, null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${VALID_DATA.name}~~${VALID_DATA.emailAddress}~~Reference number: ${VALID_DATA.referenceNumber}\n\nDate of Claim: \n\n${VALID_DATA.issue}`)
         })
     })
 

--- a/test/unit/routes/test-technical-help.js
+++ b/test/unit/routes/test-technical-help.js
@@ -13,13 +13,13 @@ describe('routes/help', function () {
     name: 'Joe Bloggs',
     emailAddress: 'test@test.com',
     referenceNumber: '',
-    'date-of-claim-day': '',
-    'date-of-claim-month': '',
-    'date-of-claim-year': '',
+    'date-of-claim-day': undefined,
+    'date-of-claim-month': undefined,
+    'date-of-claim-year': undefined,
     issue: 'Testing problems are occuring'
   }
 
-  var dateOfClaim
+  var dateOfClaim = ''
   var app
 
   var technicalHelpStub
@@ -53,7 +53,7 @@ describe('routes/help', function () {
         .expect(302)
         .expect(function () {
           sinon.assert.calledWith(technicalHelpStub, VALID_DATA.name, VALID_DATA.emailAddress, VALID_DATA.referenceNumber, VALID_DATA.day, VALID_DATA.month, VALID_DATA.year, VALID_DATA.issue)
-          sinon.assert.calledWith(insertTaskStub, null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${VALID_DATA.name}~~${VALID_DATA.emailAddress}~~Reference number: ${VALID_DATA.referenceNumber}\n\nDate of Claim: \n\n${VALID_DATA.issue}`)
+          sinon.assert.calledWith(insertTaskStub, null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${VALID_DATA.name}~~${VALID_DATA.emailAddress}~~Reference number: ${VALID_DATA.referenceNumber}\n\nDate of Claim: ${dateOfClaim}\n\n${VALID_DATA.issue}`)
         })
     })
 

--- a/test/unit/routes/test-technical-help.js
+++ b/test/unit/routes/test-technical-help.js
@@ -12,9 +12,14 @@ describe('routes/help', function () {
   const VALID_DATA = {
     name: 'Joe Bloggs',
     emailAddress: 'test@test.com',
+    referenceNumber: '',
+    'date-of-claim-day': undefined,
+    'date-of-claim-month': undefined,
+    'date-of-claim-year': undefined,
     issue: 'Testing problems are occuring'
   }
 
+  var dateOfClaim = undefined
   var app
 
   var technicalHelpStub
@@ -47,8 +52,8 @@ describe('routes/help', function () {
         .send(VALID_DATA)
         .expect(302)
         .expect(function () {
-          sinon.assert.calledWith(technicalHelpStub, VALID_DATA.name, VALID_DATA.emailAddress, VALID_DATA.issue)
-          sinon.assert.calledWith(insertTaskStub, null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${VALID_DATA.name}~~${VALID_DATA.emailAddress}~~${VALID_DATA.issue}`)
+          sinon.assert.calledWith(technicalHelpStub, VALID_DATA.name, VALID_DATA.emailAddress, VALID_DATA.referenceNumber, VALID_DATA.day, VALID_DATA.month, VALID_DATA.year, VALID_DATA.issue)
+          sinon.assert.calledWith(insertTaskStub, null, null, null, TaskEnums.TECHNICAL_HELP_SUBMITTED, `${VALID_DATA.name}~~${VALID_DATA.emailAddress}~~${VALID_DATA.referenceNumber}~~${dateOfClaim}~~${VALID_DATA.issue}`)
         })
     })
 

--- a/test/unit/services/domain/test-technical-help.js
+++ b/test/unit/services/domain/test-technical-help.js
@@ -6,32 +6,68 @@ describe('services/domain/technical-help', function () {
   const VALID_NAME = 'Joe Bloggs'
   const VALID_EMAIL_ADDRESS = 'test@test.com'
   const VALID_ISSUE = 'This is a test message'
+  const VALID_REFERENCE = ''
+  const VALID_DAY = '1'
+  const VALID_MONTH = '1'
+  const VALID_YEAR = '2017'
   const INVALID_NAME = ''
   const INVALID_EMAIL_ADDRESS = 'dsadasdasda'
+  const INVALID_REFERENCE = 'AB123'
+  const INVALID_DAY = '32'
+  const INVALID_MONTH = '13'
+  const INVALID_YEAR = '1000'
   const INVALID_ISSUE = new Array(1250).join('a')
 
   it('should construct a domain object given valid input', function () {
-    var technicalHelp = new TechnicalHelp(VALID_NAME, VALID_EMAIL_ADDRESS, VALID_ISSUE)
+    var technicalHelp = new TechnicalHelp(VALID_NAME, VALID_EMAIL_ADDRESS, VALID_REFERENCE, VALID_DAY, VALID_MONTH, VALID_YEAR, VALID_ISSUE)
     expect(technicalHelp.name).to.equal(VALID_NAME)
     expect(technicalHelp.emailAddress).to.equal(VALID_EMAIL_ADDRESS)
+    expect(technicalHelp.referenceNumber).to.equal(VALID_REFERENCE)
+    expect(technicalHelp.dateOfClaim.format('D')).to.equal(VALID_DAY)
+    expect(technicalHelp.dateOfClaim.format('M')).to.equal(VALID_MONTH)
+    expect(technicalHelp.dateOfClaim.format('YYYY')).to.equal(VALID_YEAR)
     expect(technicalHelp.issue).to.equal(VALID_ISSUE)
   })
 
   it('should throw an error if passed invalid name', function () {
     expect(function () {
-      new TechnicalHelp(INVALID_NAME, VALID_EMAIL_ADDRESS, VALID_ISSUE).isValid()
+      new TechnicalHelp(INVALID_NAME, VALID_EMAIL_ADDRESS, VALID_REFERENCE, VALID_DAY, VALID_MONTH, VALID_YEAR, VALID_ISSUE).isValid()
     }).to.throw(ValidationError)
   })
 
   it('should throw an error if passed invalid email address', function () {
     expect(function () {
-      new TechnicalHelp(VALID_NAME, INVALID_EMAIL_ADDRESS, VALID_ISSUE).isValid()
+      new TechnicalHelp(VALID_NAME, INVALID_EMAIL_ADDRESS, VALID_REFERENCE, VALID_DAY, VALID_MONTH, VALID_YEAR, VALID_ISSUE).isValid()
+    }).to.throw(ValidationError)
+  })
+
+  it('should throw an error if passed invalid reference', function () {
+    expect(function () {
+      new TechnicalHelp(VALID_NAME, VALID_EMAIL_ADDRESS, INVALID_REFERENCE, VALID_DAY, VALID_MONTH, VALID_YEAR, VALID_ISSUE).isValid()
+    }).to.throw(ValidationError)
+  })
+
+  it('should throw an error if passed invalid day', function () {
+    expect(function () {
+      new TechnicalHelp(VALID_NAME, VALID_EMAIL_ADDRESS, VALID_REFERENCE, INVALID_DAY, VALID_MONTH, VALID_YEAR, VALID_ISSUE).isValid()
+    }).to.throw(ValidationError)
+  })
+
+  it('should throw an error if passed invalid month', function () {
+    expect(function () {
+      new TechnicalHelp(VALID_NAME, VALID_EMAIL_ADDRESS, VALID_REFERENCE, VALID_DAY, INVALID_MONTH, VALID_YEAR, VALID_ISSUE).isValid()
+    }).to.throw(ValidationError)
+  })
+
+  it('should throw an error if passed invalid year', function () {
+    expect(function () {
+      new TechnicalHelp(VALID_NAME, VALID_EMAIL_ADDRESS, VALID_REFERENCE, VALID_DAY, VALID_MONTH, INVALID_YEAR, VALID_ISSUE).isValid()
     }).to.throw(ValidationError)
   })
 
   it('should throw an error if passed invalid issue', function () {
     expect(function () {
-      new TechnicalHelp(VALID_NAME, VALID_EMAIL_ADDRESS, INVALID_ISSUE).isValid()
+      new TechnicalHelp(VALID_NAME, VALID_EMAIL_ADDRESS, VALID_REFERENCE, VALID_DAY, VALID_MONTH, VALID_YEAR, INVALID_ISSUE).isValid()
     }).to.throw(ValidationError)
   })
 })


### PR DESCRIPTION
apvs-0050 addition of 2 extra help page fields, reference number and date of claim, and minor text changes. These additional fields are added to the Zendesk ticket. These fields are optional, so can be blank, but if any data is added to them, it is validated.

The format of the date added to Zendesk is done without using moment.format() as when it is used, the tests do not work, as POSTs to /help return a 500 error.
