### PR TITLE
Checking if checkExpenseIsEnabled returns nothing. In this case the c…

### DIFF
--- a/app/routes/apply/eligibility/claim/file-upload.js
+++ b/app/routes/apply/eligibility/claim/file-upload.js
@@ -67,7 +67,9 @@ function get (req, res) {
     // check that the expense is still enabled
     checkExpenseIsEnabled(req.query.claimExpenseId)
       .then(function (claimExpense) {
-        if (claimExpense[0].IsEnabled) {
+        if (claimExpense.length === 0) {
+          renderFileUploadPage(req, res)
+        } else if (claimExpense[0].IsEnabled) {
           renderFileUploadPage(req, res)
         } else {
           // claimant has probably clicked the back button after deleting expense


### PR DESCRIPTION
…laim has already been moved to the internal database and we do not need to check if the expense is enabled as only enabled expenses are copied over.

SQUASHED COMMIT MESSAGE (e.g. apvs-123 - this message accurately describes my changes replacing the squashed concatenation)
 
High-level description - a few sentences on the overall context and goals for the PR's commits.

## Checklist

- [ ] Unit tests
- [ ] End-to-End tests
- [ ] Code coverage checked
- [ ] Coding standards
- [ ] Error Handling
- [ ] Security/performance considered?
- [ ] Deployment changes considered?
- [ ] README updated
